### PR TITLE
Add Dorothy to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [constellagent](https://github.com/owengretzinger/constellagent) - macOS app for running multiple AI agents with their own terminal, editor, and git worktree.
 - [crystal](https://github.com/stravu/crystal) - Run multiple Codex and Claude Code sessions in parallel git worktrees.
 - [dmux](https://github.com/standardagents/dmux) - Parallel agents with tmux and worktrees.
+- [dorothy](https://github.com/Charlie85270/Dorothy) - Desktop app to orchestrate multiple AI CLI agents with automations, Kanban management, and MCP servers.
 - [emdash](https://github.com/generalaction/emdash) - Run multiple coding agents in parallel.
 - [humanlayer](https://github.com/humanlayer/humanlayer) - Get AI coding agents to solve hard problems in complex codebases.
 - [jat](https://github.com/joewinke/jat) - The World's First Agentic IDE.


### PR DESCRIPTION
## Summary

- Adds [Dorothy](https://github.com/Charlie85270/Dorothy) to the **Parallel Agent Runners** section in alphabetical order

Dorothy is an open-source desktop app for orchestrating multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously. Key features include:

- Run and monitor multiple AI coding agents in parallel from a single UI
- Built-in automations and Kanban task management
- Remote control via Telegram
- 5 MCP servers (vault, kanban, orchestrator, and more)
- Multi-provider support (Claude Code, Codex, Gemini)

## Checklist

- [x] Entry follows the existing format: `- [name](url) - Description.`
- [x] Placed in alphabetical order within the correct section
- [x] Description is concise and accurate