### PR TITLE
Add IM.codes - The IM for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [ghast](https://github.com/aidenybai/ghast) - Multitask with multiple terminals.
 - [herdr](https://github.com/ogulcancelik/herdr) - Agent-aware terminal multiplexer with persistent workspaces, tabs, panes, and status detection for CLI coding agents.
 - [humanlayer](https://github.com/humanlayer/humanlayer) - Get AI coding agents to solve hard problems in complex codebases.
+- [IM.codes](https://github.com/im4codes/imcodes) - Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents, built for away-from-desk continuation with terminal access, file browsing, git views, localhost preview, notifications, scheduled tasks, and multi-agent workflows.
 - [ivy-tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) - Open-source AI coding orchestrator that manages Claude Code, Codex, Antigravity, Copilot, and OpenCode through a plan-based lifecycle with verification gates, self-improving memory, and human-in-the-loop checkpoints. ([tendril.ivy.app](https://tendril.ivy.app))
 - [jat](https://github.com/joewinke/jat) - The World's First Agentic IDE.
 - [jean](https://github.com/coollabsio/jean) - Desktop & web app for orchestrating coding agents (Claude, Codex, OpenCode) across projects and git worktrees.


### PR DESCRIPTION
Add IM.codes under **Parallel Agent Runners**.

IM.codes is a mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents. The main differentiator is away-from-desk continuation: it keeps long-running agent workflows within reach from phone or browser with terminal access, file browsing, git views, localhost preview, notifications, scheduled tasks / cron jobs, and multi-agent workflows.

Repo: https://github.com/im4codes/imcodes