### PR TITLE
Add sortie to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [mux](https://github.com/coder/mux) - A desktop app for isolated, parallel agentic development.
 - [openkanban](https://github.com/techdufus/openkanban) - TUI kanban board for orchestrating AI coding agents.
 - [parallel-code](https://github.com/johannesjo/parallel-code) - Desktop app for orchestrating multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees with built-in diff viewer and one-click merge.
+- [sortie](https://github.com/sortie-ai/sortie) - Turns issue tracker tickets into autonomous coding agent sessions. Agent-agnostic, tracker-agnostic, single Go binary with SQLite persistence.
 - [subtask](https://github.com/zippoxer/subtask) - Claude Skill to do tasks with subagents in Git worktrees.
 - [supacode](https://github.com/supabitapp/supacode) - Native macOS coding agent orchestrator.
 - [superset](https://github.com/superset-sh/superset) - A terminal built for coding agents.


### PR DESCRIPTION
Adds [sortie](https://github.com/sortie-ai/sortie) to the Parallel Agent Runners section.

Sortie is an issue-driven agent orchestrator that turns tracker tickets into autonomous coding agent sessions. Key features:

- **Agent-agnostic:** pluggable agent adapters (Claude Code, Copilot CLI, more planned)
- **Tracker-agnostic:** pluggable issue tracker adapters (Jira, GitHub Issues, more planned)
- **Single Go binary:** zero external dependencies, zero CGo
- **SQLite persistence:** full session state with handoff support for long-running tasks

Website: https://docs.sortie-ai.com