### PR TITLE
Add CliDeck to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [bernstein](https://github.com/chernistry/bernstein) - Deterministic orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits. Zero LLM tokens on coordination.
 - [claude-squad](https://github.com/smtg-ai/claude-squad) - Manage multiple AI terminal agents in background.
 - [claude_code_bridge](https://github.com/bfly123/claude_code_bridge) - Real-time multi-AI collaboration.
+- [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) in one browser window. Live status, session resume, autopilot routing between agents, and full control from a phone while away.
 - [collaborator](https://github.com/collaborator-ai/collab-public) - A place to create with agents.
 - [cmux](https://github.com/manaflow-ai/cmux) - Open-source platform for running multiple coding agents in parallel.
 - [CodexMonitor](https://github.com/Dimillian/CodexMonitor) - Orchestrate multiple Codex agents across local workspaces.


### PR DESCRIPTION
Adds [clideck](https://github.com/rustykuntz/clideck) to the Parallel Agent Runners section.

clideck is a local browser dashboard for managing multiple AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) in a WhatsApp-like interface. it manages terminal sessions with live status detection, session resume, autopilot routing between agents, and full control from a phone while away.

- runs locally, no data leaves the machine
- MIT license
- install: `npm install -g clideck`
- docs: https://docs.clideck.dev