### PR TITLE
Add Corellis — multi-agent governance for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ AI assistants that bridge to messaging platforms and other interfaces.
 - [assistant](https://github.com/kcosr/assistant) - Panel-based personal assistant with a plugin architecture for productivity workflows.
 - [babyagi3](https://github.com/yoheinakajima/babyagi3) - A minimal AI agent you configure once, then run through natural language.
 - [cashclaw](https://github.com/moltlaunch/cashclaw) - An autonomous agent that takes work, does work, gets paid, and gets better at it.
+- [corellis](https://github.com/CorellisOrg/corellis) - Multi-agent governance framework for OpenClaw — goal decomposition, fleet-wide memory, correction propagation, and approval workflows for 20+ agent fleets.
 - [ClawWork](https://github.com/HKUDS/ClawWork) - OpenClaw as your AI coworker.
 - [CoPaw](https://github.com/agentscope-ai/CoPaw) - Your Personal AI Assistant.
 - [denchclaw](https://github.com/DenchHQ/denchclaw) - Managed OpenClaw framework for CRM, sales automation, and outreach agents.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Systems where multiple specialized agents actively coordinate, communicate, and 
 - [claude_codex_bridge](https://github.com/SeemSeam/claude_codex_bridge) - Workspace for mixing different vendors' CLI agents in one visible collaboration session.
 - [ClawTeam](https://github.com/HKUDS/ClawTeam) - Agents spawn and manage their own teammates from one command, coordinating through file-based or P2P inboxes across tmux worktrees.
 - [CompanyHelm](https://github.com/CompanyHelm/companyhelm) - Distributed orchestrator with task management and direct agent-to-agent conversations.
+- [corellis](https://github.com/CorellisOrg/corellis) - Multi-agent governance framework for OpenClaw — goal decomposition, fleet-wide memory, correction propagation, and approval workflows for 20+ agent fleets.
 - [Fusion](https://github.com/Runfusion/Fusion) - Multi-node orchestrator with a kanban board, plan-review-execute gates, per-task worktrees, and hierarchical missions.
 - [gastown](https://github.com/gastownhall/gastown) - Scales to 20-30 agents with a coordinator, git-backed issue tracking, health watchdogs, and a Bors-style merge queue.
 - [hcom](https://github.com/aannoo/hcom) - Lets agents message, watch, and spawn each other across terminals. Claude Code, Codex, Antigravity, Cursor, OpenCode, Kilo, and more.


### PR DESCRIPTION
Adding [Corellis](https://github.com/CorellisOrg/corellis) to the Personal Assistants section.

Corellis is an open-source multi-agent governance framework built on OpenClaw. It provides goal decomposition (GoalOps), fleet-wide memory, correction propagation, and approval workflows — designed for managing fleets of 20+ agents in production.

Currently running 28 agents on a single server, coordinating through OpenClaw's gateway.