### PR TITLE
Add AgentsMesh to Multi-Agent Swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI assistants that bridge to messaging platforms and other interfaces.
 
 Systems for coordinating multiple specialized agents working together.
 
+- [agentsmesh](https://github.com/AgentsMesh/AgentsMesh) - The AI Agent Workforce Platform. Spin up remote AI workstations (AgentPods) with PTY sandboxes and git worktree isolation, coordinate multi-agent collaboration across channels and pod bindings, and manage tasks with a built-in Kanban. Self-hostable with BYOK. Supports Claude Code, Codex CLI, Gemini CLI, Aider, and OpenCode.
 - [antfarm](https://github.com/snarktank/antfarm) - Build your agent team in OpenClaw with one command.
 - [automata](https://github.com/sentientwave/automata) - Agent swarming organization system.
 - [claude-flow](https://github.com/ruvnet/claude-flow) - Deploy multi-agent swarms with coordinated workflows.


### PR DESCRIPTION
## What
Adding [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) to the **Multi-Agent Swarms** section.

## Why it fits
AgentsMesh is a self-hostable AI Agent Workforce Platform that coordinates multiple specialized coding agents. Core concepts:

- **AgentPods** — remote AI workstations, each with PTY sandbox + git worktree isolation
- **Channels + pod bindings** — multi-agent collaboration topology
- **Kanban** — built-in task management with ticket-pod binding
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode, and custom terminal agents
- Multi-Git provider (GitHub / GitLab / Gitee), multi-tenant (Org > Team > User), BYOK

Stable: 1.5k+ stars, v0.28.0 release (2026-04-15).

## Placement
Alphabetically before \`antfarm\` in Multi-Agent Swarms (ag < an).

## Format
\`\`\`
- [agentsmesh](https://github.com/AgentsMesh/AgentsMesh) - The AI Agent Workforce Platform. Spin up remote AI workstations (AgentPods) with PTY sandboxes and git worktree isolation, coordinate multi-agent collaboration across channels and pod bindings, and manage tasks with a built-in Kanban. Self-hostable with BYOK. Supports Claude Code, Codex CLI, Gemini CLI, Aider, and OpenCode.
\`\`\`