### PR TITLE
Add Dex project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,5 +116,6 @@ Projects implementing the "keep running until done" pattern.
 - [ralph-orchestrator](https://github.com/mikeyobrien/ralph-orchestrator) - Hat-based orchestration that keeps agents in a loop until done.
 - [ralph-tui](https://github.com/subsy/ralph-tui) - Orchestrate AI coding agents to work through task lists autonomously.
 - [ralphy](https://github.com/michaelshimeles/ralphy) - Runs AI agents on tasks until done.
+- [Dex](https://github.com/francescoalemanno/dex) - Structured Ralph orchestrator with human-gated planning, programmatic task tracking, parallel multi-reviewer code review, automatic retries with backoff, and autonomous dead-end-aware research loops inspired by Karpathy's autoresearch; supports 7 CLI backends and ships cross-platform binaries.
 - [toryo](https://github.com/JesseRWeigel/toryo) - Intelligent agent orchestrator with trust-based delegation, quality ratcheting (git commit/revert), and Ralph Loop retries. Chains Claude Code, Aider, Gemini CLI, Ollama.
 - [wreckit](https://github.com/mikehostetler/wreckit) - Run Ralph Wiggum Loop over your roadmap.


### PR DESCRIPTION
Added Dex project to the list of AI development tools.

> Dex wraps the Ralph loop in a deterministic orchestrator: plan → apply → review, with the agent never touching code until the user approves the plan. It adds parallel review fanout (5 specialized reviewers), dead-end-aware research loops inspired by Karpathy's autoresearch, and CLI-agnostic execution across opencode, claude, codex, gemini, droid, pi, and raijin.
Ofcourse it also supports a bare mode where you can run the iconic raw Ralph-Wiggum loop for a given number of iterations