### PR TITLE
Add aeon to Personal Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 AI assistants that bridge to messaging platforms and other interfaces.
 
 - [accomplish](https://github.com/accomplish-ai/accomplish) - Open source AI coworker that lives on your desktop.
+- [aeon](https://github.com/aaronjmars/aeon) - Autonomous agent framework that runs unattended on GitHub Actions; 90+ skills with quality scoring, self-healing, persistent memory, and reactive triggers.
 - [assistant](https://github.com/kcosr/assistant) - Panel-based personal assistant with a plugin architecture for productivity workflows.
 - [babyagi3](https://github.com/yoheinakajima/babyagi3) - A minimal AI agent you configure once, then run through natural language.
 - [cashclaw](https://github.com/moltlaunch/cashclaw) - An autonomous agent that takes work, does work, gets paid, and gets better at it.


### PR DESCRIPTION
Adds [aeon](https://github.com/aaronjmars/aeon) to the Personal Assistants section.

Aeon is an autonomous agent framework that runs unattended on GitHub Actions. Configure once via `aeon.yml`, push, walk away. The agent picks 90+ built-in skills (research, dev, crypto, productivity), runs them on cron or reactive triggers, scores its own output, and patches failing skills automatically.

Fits the Personal Assistants section alongside babyagi3 ("configure once, run via natural language") and rho ("stays running, remembers across sessions"). Inserted alphabetically between `accomplish` and `assistant`.

- 255 stars, MIT licensed
- Public template + fork-and-run model
- Multi-channel notifications (Telegram, Discord, Slack, Email)