### PR TITLE
Add claude-code-dual-build to Multi-Agent Swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Systems for coordinating multiple specialized agents working together.
 - [agentsmesh](https://github.com/AgentsMesh/AgentsMesh) - The AI Agent Workforce Platform. Spin up remote AI workstations (AgentPods) with PTY sandboxes and git worktree isolation, coordinate multi-agent collaboration across channels and pod bindings, and manage tasks with a built-in Kanban. Self-hostable with BYOK. Supports Claude Code, Codex CLI, Gemini CLI, Aider, and OpenCode.
 - [antfarm](https://github.com/snarktank/antfarm) - Build your agent team in OpenClaw with one command.
 - [automata](https://github.com/sentientwave/automata) - Agent swarming organization system.
+- [claude-code-dual-build](https://github.com/cjcsecurity/claude-code-dual-build) - Symmetric multi-agent build for Claude Code + Codex with mandatory bidirectional cross-review. Splits a coding task ~50/50 between Claude and Codex, runs both in parallel in isolated git worktrees, then has the opposite model review each diff before consolidation. Lightweight skill + four agents.
 - [claude-flow](https://github.com/ruvnet/claude-flow) - Deploy multi-agent swarms with coordinated workflows.
 - [clawe](https://github.com/getclawe/clawe) - Multi-agent coordination system: think Trello for OpenClaw agents.
 - [ClawTeam](https://github.com/HKUDS/ClawTeam) - Agent Swarm Intelligence (One Command → Full Automation).


### PR DESCRIPTION
Adding `claude-code-dual-build` — a Claude Code skill that orchestrates symmetric Claude+Codex builds with mandatory bidirectional cross-review.

**Why I think it fits Multi-Agent Swarms specifically:** the skill coordinates specialized roles (claude-builder, codex-builder, claude-reviewer, codex-reviewer), runs them in parallel in isolated git worktrees, and has each model review the *opposite* model's diff before consolidation. The cross-review is the load-bearing piece — different model families catch different bug classes (e.g., on a real `mission-control` run, Claude reviewing Codex's stop-button code caught a SIGKILL→ESRCH race + an `ss` permission-model UX bug that the implementing model missed). This shape feels closer to coordinated specialists than a parallel runner per se.

Repo: https://github.com/cjcsecurity/claude-code-dual-build

The README has worked examples + a comparison vs. existing patterns in this exact space (asymmetric, single-model parallel, sequential pipeline, consensus drafting, multi-reviewer fan-out, communication bridge) — happy to revise placement if you'd prefer it land elsewhere.