### PR TITLE
Add multica project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [jean](https://github.com/coollabsio/jean) - Desktop & web app for orchestrating coding agents (Claude, Codex, OpenCode) across projects and git worktrees.
 - [lalph](https://github.com/tim-smart/lalph) - LLM agent orchestrator driven by your chosen source of issues.
 - [mux](https://github.com/coder/mux) - A desktop app for isolated, parallel agentic development.
+- [multica](https://github.com/multica-ai/multica) - Agent-first kanban board, multi-runtime support.
 - [openkanban](https://github.com/techdufus/openkanban) - TUI kanban board for orchestrating AI coding agents.
 - [parallel-code](https://github.com/johannesjo/parallel-code) - Desktop app for orchestrating multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees with built-in diff viewer and one-click merge.
 - [sortie](https://github.com/sortie-ai/sortie) - Turns issue tracker tickets into autonomous coding agent sessions. Agent-agnostic, tracker-agnostic, single Go binary with SQLite persistence.


### PR DESCRIPTION
It's super popular, I started using it myself today and it's the drop-in replacement for live kanban you've been looking for.