### PR TITLE
Add agenttier to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [agent-kanban](https://github.com/saltbo/agent-kanban) - Agent-first kanban board with leader-worker model, cryptographic agent identity, and multi-runtime support (Claude Code, Codex, Gemini CLI).
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - A terminal session manager for AI coding agents on Linux and macOS.
 - [agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator) - Agentic orchestrator for parallel coding agents.
+- [agenttier](https://github.com/agenttier/agenttier) - Kubernetes-native runtime that runs each AI coding agent in its own Pod + PVC sandbox, with default-deny NetworkPolicy and a streaming SSE invoke API. Run multiple agents in parallel by creating multiple Sandbox CRs.
 - [ai-maestro](https://github.com/23blocks-OS/ai-maestro) - Dashboard for orchestrating Claude, Aider, and Cursor agents across machines.
 - [aizen](https://github.com/vivy-company/aizen) - macOS workspace for managing git worktrees with integrated agent sessions.
 - [amux](https://github.com/andyrewlee/amux) - TUI for easily running parallel coding agents.


### PR DESCRIPTION
This PR adds [agenttier](https://github.com/agenttier/agenttier) under `## Parallel Agent Runners`.

AgentTier is a Kubernetes-native runtime for AI coding agents. Each `Sandbox` CR creates a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation. Running N agents in parallel = creating N Sandbox CRs. Each sandbox is driven via a streaming Server-Sent Events invoke API (`POST /configure` to install agent code, then `POST /invoke` to stream stdout/stderr/exit). Reference templates ship for Claude Code + AWS Bedrock, OpenHands, and a model-free LangGraph agent. Apache-2.0.

Placement: alphabetically between `agent-orchestrator` and `ai-maestro` in **Parallel Agent Runners**, matching the section's sort order. The diff is a single-line addition.

Disclosure: I'm a contributor to AgentTier.
