### PR TITLE
Add clave to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [bernstein](https://github.com/chernistry/bernstein) - Deterministic orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits. Zero LLM tokens on coordination.
 - [claude-squad](https://github.com/smtg-ai/claude-squad) - Manage multiple AI terminal agents in background.
 - [claude_code_bridge](https://github.com/bfly123/claude_code_bridge) - Real-time multi-AI collaboration.
+- [clave](https://github.com/codika-io/clave) - Native macOS app for running multiple Claude Code sessions in parallel with split/grid layouts, session groups, SSH remote sessions, and usage analytics. Local-first and MIT.
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) in one browser window. Live status, session resume, autopilot routing between agents, and full control from a phone while away.
 - [cmux](https://github.com/manaflow-ai/cmux) - Open-source platform for running multiple coding agents in parallel.
 - [CodexMonitor](https://github.com/Dimillian/CodexMonitor) - Orchestrate multiple Codex agents across local workspaces.


### PR DESCRIPTION
Adds [clave](https://github.com/codika-io/clave) to the **Parallel Agent Runners** section (alphabetical placement, after `claude_code_bridge`).

Clave is a native macOS app for running multiple Claude Code sessions in parallel — split/grid layouts, session groups, SSH remote sessions, and usage analytics. Free, MIT, local-first. It fits squarely alongside existing entries like constellagent, supacode, and cmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)