### PR TITLE
Add Agent Teams to Multi-Agent Swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ AI assistants that bridge to messaging platforms and other interfaces.
 
 Systems for coordinating multiple specialized agents working together.
 
+- [Agent Teams](https://github.com/777genius/agent-teams-ai) - Desktop app where you give high-level commands to autonomous AI agent teams across Claude, Codex, and OpenCode, and agents handle the work themselves with inter-agent messaging, Kanban task management, and built-in code review. Supports 200+ models and 75+ LLM providers.
 - [agentsmesh](https://github.com/AgentsMesh/AgentsMesh) - The AI Agent Workforce Platform. Spin up remote AI workstations (AgentPods) with PTY sandboxes and git worktree isolation, coordinate multi-agent collaboration across channels and pod bindings, and manage tasks with a built-in Kanban. Self-hostable with BYOK. Supports Claude Code, Codex CLI, Gemini CLI, Aider, and OpenCode.
 - [antfarm](https://github.com/snarktank/antfarm) - Build your agent team in OpenClaw with one command.
 - [automata](https://github.com/sentientwave/automata) - Agent swarming organization system.


### PR DESCRIPTION
Adds [Agent Teams](https://github.com/777genius/agent-teams-ai) to the Multi-Agent Swarms section.

Agent Teams is a local-first desktop app for coordinating autonomous AI agent teams across Claude, Codex, and OpenCode. You give high-level commands, then agents handle the work themselves: they run in parallel, message each other, manage Kanban tasks, and use a built-in review workflow.

Why it fits this list:

- Matches the section definition: coordinating multiple specialized agents working together
- Uses the existing README format: one Markdown bullet with name, link, and short description
- Added alphabetically before agentsmesh
- Keeps the PR minimal: only README.md, one insertion, no extra files
- Checked repository structure: no separate CONTRIBUTING, .github, or PR template is present

Links:

- GitHub: https://github.com/777genius/agent-teams-ai
- Homepage: https://777genius.github.io/agent-teams-ai/
- License: AGPL-3.0
- Supports: Claude, Codex, OpenCode, 200+ models, and 75+ LLM providers