### PR TITLE
Add driftless to Autonomous Loop Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Projects implementing the "keep running until done" pattern.
 - [ralph-orchestrator](https://github.com/mikeyobrien/ralph-orchestrator) - Hat-based orchestration that keeps agents in a loop until done.
 - [ralph-tui](https://github.com/subsy/ralph-tui) - Orchestrate AI coding agents to work through task lists autonomously.
 - [ralphy](https://github.com/michaelshimeles/ralphy) - Runs AI agents on tasks until done.
+- [driftless](https://github.com/mizan0515/driftless) - Non-developer-operable overnight loop that drives both Claude Code and Codex from one source of truth; surveys issues, runs parallel workers, self-recovers, and opens/merges PRs behind human-only gates, in a repo-local isolated home that never touches host-global config.
 - [Dex](https://github.com/francescoalemanno/dex) - Structured Ralph orchestrator with human-gated planning, programmatic task tracking, parallel multi-reviewer code review, automatic retries with backoff, and autonomous dead-end-aware research loops inspired by Karpathy's autoresearch; supports 7 CLI backends and ships cross-platform binaries.
 - [toryo](https://github.com/JesseRWeigel/toryo) - Intelligent agent orchestrator with trust-based delegation, quality ratcheting (git commit/revert), and Ralph Loop retries. Chains Claude Code, Aider, Gemini CLI, Ollama.
 - [wreckit](https://github.com/mikehostetler/wreckit) - Run Ralph Wiggum Loop over your roadmap.


### PR DESCRIPTION
Adds **driftless** to the *Autonomous Loop Runners* section — it implements the "keep running until done" pattern.

What it is: a non-developer-operable overnight loop that drives **both Claude Code and Codex** from one source of truth. You give a goal in plain language; it surveys open issues, runs parallel workers, self-recovers from worker failures, and opens/merges PRs behind human-only gates. It runs in a repo-local isolated home (`CLAUDE_CONFIG_DIR`/`CODEX_HOME` pointed inside the repo) so it never reads or mutates your host-global config.

Why this section: the default mode is continuous improvement until the backlog is exhausted (a sentinel line, not a status word, ends the loop), with a containment gate, mirror-parity between the two tool profiles, and an exhaustion-ledger so "done" can't hide unfinished work.

- Repo: https://github.com/mizan0515/driftless
- MIT, public, CI green (Windows + Linux). One entry, alphabetical placement in the section.

Thanks for maintaining the list!