### PR TITLE
Add doforu to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [constellagent](https://github.com/owengretzinger/constellagent) - macOS app for running multiple AI agents with their own terminal, editor, and git worktree.
 - [crystal](https://github.com/stravu/crystal) - Run multiple Codex and Claude Code sessions in parallel git worktrees.
 - [dmux](https://github.com/standardagents/dmux) - Parallel agents with tmux and worktrees.
+- [doforu](https://github.com/yctech2026/Doforu-APP) - Desktop-grade agent orchestrator with Plan/Agent/Orchestrator modes, 15+ model support, and natural language Skills. One prompt, multi-agent parallel delivery.
 - [dorothy](https://github.com/Charlie85270/Dorothy) - Desktop app to orchestrate multiple AI CLI agents with automations, Kanban management, and MCP servers.
 - [emdash](https://github.com/generalaction/emdash) - Run multiple coding agents in parallel.
 - [ghast](https://github.com/aidenybai/ghast) - Multitask with multiple terminals.


### PR DESCRIPTION
## Add Doforu to Parallel Agent Runners

Doforu is a desktop-grade AI agent orchestrator — not an IDE, not a CLI. Users describe a task in natural language, and Doforu auto-decomposes it, dispatches multiple sub-agents in parallel, and delivers complete results.

**Why it fits this list:**
- Multi-agent parallel execution (Orchestrator mode)
- Supports 15+ models: Claude Opus 4.7, GPT-5.5, Gemini 3.1, DeepSeek V4, Qwen, Kimi, GLM, and local models via Ollama/vLLM
- Natural language Skills system (create once, reuse forever)
- MCP ecosystem integration
- Desktop-native (macOS + Windows), 100% local privacy
- Three execution modes: Plan / Agent / Orchestrator

**Placement:** Between `dmux` and `dorothy` (alphabetical order).

**Links:**
- GitHub: https://github.com/yctech2026/Doforu-APP
- Website: https://doforu.ai