### PR TITLE
Add agentbox to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [agent-kanban](https://github.com/saltbo/agent-kanban) - Agent-first kanban board with leader-worker model, cryptographic agent identity, and multi-runtime support (Claude Code, Codex, Gemini CLI).
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - A terminal session manager for AI coding agents on Linux and macOS.
 - [agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator) - Agentic orchestrator for parallel coding agents.
+- [agentbox](https://github.com/madarco/agentbox) - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.
 - [agenttier](https://github.com/agenttier/agenttier) - Kubernetes-native runtime that runs each AI coding agent in its own Pod + PVC sandbox, with default-deny NetworkPolicy and a streaming SSE invoke API. Run multiple agents in parallel by creating multiple Sandbox CRs.
 - [ai-maestro](https://github.com/23blocks-OS/ai-maestro) - Dashboard for orchestrating Claude, Aider, and Cursor agents across machines.
 - [AGX](https://github.com/ramarlina/agx) - Local-first agent orchestrator with parallel execution, wake-work-sleep checkpointing, and human-in-the-loop gates.


### PR DESCRIPTION
Adds [**agentbox**](https://github.com/madarco/agentbox) to the **Parallel Agent Runners** section.

AgentBox runs multiple coding agents in parallel, each teleported into its own sandboxed box — local Docker (FUSE overlay) or cloud VMs via Hetzner/Daytona/Vercel/E2B — with sub-1s starts from checkpoints, a per-box browser + VS Code, and git credentials kept on the host. Works with Claude Code, Codex, and OpenCode. MIT, npm `@madarco/agentbox`.

Placed alphabetically between `agent-orchestrator` and `agenttier`, single-line entry matching the section format.