### PR TITLE
Add TWZRD Agent Intel - on-chain trust scoring for AI agent wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ AI assistants that bridge to messaging platforms and other interfaces.
 
 Systems for coordinating multiple specialized agents working together.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring MCP server for AI agent wallets on Solana. Verify agent wallet identity and reputation before x402 micropayments — a trust primitive for multi-agent payment flows.
 - [Agent Teams](https://github.com/777genius/agent-teams-ai) - Desktop app where you give high-level commands to autonomous AI agent teams across Claude, Codex, and OpenCode, and agents handle the work themselves with inter-agent messaging, Kanban task management, and built-in code review. Supports 200+ models and 75+ LLM providers.
 - [agentsmesh](https://github.com/AgentsMesh/AgentsMesh) - The AI Agent Workforce Platform. Spin up remote AI workstations (AgentPods) with PTY sandboxes and git worktree isolation, coordinate multi-agent collaboration across channels and pod bindings, and manage tasks with a built-in Kanban. Self-hostable with BYOK. Supports Claude Code, Codex CLI, Gemini CLI, Aider, and OpenCode.
 - [antfarm](https://github.com/snarktank/antfarm) - Build your agent team in OpenClaw with one command.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Multi-Agent Swarms section as a trust and identity primitive.

TWZRD Agent Intel is an MCP server that provides on-chain trust scoring for AI agent wallets on Solana. In multi-agent orchestration systems where agents make or receive x402 micropayments, TWZRD enables agents to verify counterpart wallet identity and reputation before transacting.

**MCP Configuration:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Free tools:**
- `score_agent(wallet)` — Trust score + on-chain reputation for any Solana wallet
- `preflight_check(wallet)` — Validates agent wallet before payment acceptance
- `get_trust_receipt(wallet)` — Cryptographic on-chain trust receipt (paid, x402)