### PR TITLE
Add company-skill to Autonomous Loop Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Systems for coordinating multiple specialized agents working together.
 
 Projects implementing the "keep running until done" pattern.
 
+- [company-skill](https://github.com/jagmarques/company-skill) - Claude Code skill that defines a team in a markdown file, hands it a goal, and keeps looping until every success criterion passes with reproduced evidence. A stop hook blocks exit until criteria.json is satisfied, pinned by a test suite that runs in CI.
 - [ralph-claude-code](https://github.com/frankbria/ralph-claude-code) - Autonomous AI development loop for Claude Code with intelligent exit detection.
 - [ralph-orchestrator](https://github.com/mikeyobrien/ralph-orchestrator) - Hat-based orchestration that keeps agents in a loop until done.
 - [ralph-tui](https://github.com/subsy/ralph-tui) - Orchestrate AI coding agents to work through task lists autonomously.


### PR DESCRIPTION
Adds [company-skill](https://github.com/jagmarques/company-skill) to the **Autonomous Loop Runners** section.

company-skill is a Claude Code skill for goal-driven multi-agent orchestration. You define a team in a markdown file, hand it a goal, and the loop keeps running until every success criterion passes with reproduced evidence. A stop hook physically blocks exit until criteria.json is satisfied. A 22-check test suite pins that guard and runs in CI on every pull request.

Why it fits this section:

- Matches the section definition: implements the "keep running until done" pattern with a hard stop gate
- Single-line entry in the existing README format
- Placed at the top of the section (entries are not in alphabetical order in this section)
- Only README.md changed, one insertion, no extra files
- No PR or CONTRIBUTING template found in the repo; format follows the pattern of recent merged PRs (#56, #51)
- MIT license, repo created 2026-04-07 (over one week old)

Links:

- GitHub: https://github.com/jagmarques/company-skill
- npm: https://www.npmjs.com/package/company-skill
- License: MIT