### PR TITLE
Add pulpo to Parallel Agent Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [openkanban](https://github.com/techdufus/openkanban) - TUI kanban board for orchestrating AI coding agents.
 - [Orca](https://github.com/stablyai/orca) - IDE for running multiple CLI coding agents side-by-side across isolated git worktrees.
 - [parallel-code](https://github.com/johannesjo/parallel-code) - Desktop app for orchestrating multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees with built-in diff viewer and one-click merge.
+- [pulpo](https://github.com/darioblanco/pulpo) - Self-hosted daemon for running coding agents as background workers across your machines (Tailscale-aware), with session lifecycle, watchdog interventions, cron scheduling, token/cost tracking, and a mobile-first web UI. Agent-agnostic, single Rust binary with SQLite persistence.
 - [sortie](https://github.com/sortie-ai/sortie) - Turns issue tracker tickets into autonomous coding agent sessions. Agent-agnostic, tracker-agnostic, single Go binary with SQLite persistence.
 - [subtask](https://github.com/zippoxer/subtask) - Claude Skill to do tasks with subagents in Git worktrees.
 - [supacode](https://github.com/supabitapp/supacode) - Native macOS coding agent orchestrator.


### PR DESCRIPTION
Adds [pulpo](https://github.com/darioblanco/pulpo) — a self-hosted daemon that runs coding agents (Claude Code, Codex, Aider, Goose, or any CLI) as background workers across multiple machines over Tailscale. Single Rust binary with SQLite persistence, session lifecycle state machine, watchdog interventions (memory/idle), cron scheduling, token/cost tracking, and a mobile-first embedded web UI.

Inserted alphabetically in the Parallel Agent Runners section, matching the existing entry format.