### PR TITLE
Refine the Fusion entry to match the list style

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Systems for coordinating multiple specialized agents working together.
 - [clawe](https://github.com/getclawe/clawe) - Multi-agent coordination system: think Trello for OpenClaw agents.
 - [ClawTeam](https://github.com/HKUDS/ClawTeam) - Agent Swarm Intelligence (One Command → Full Automation).
 - [CompanyHelm](https://github.com/CompanyHelm/companyhelm) - Distributed multi-agent orchestrator with task management and agent-to-agent conversations
-- [fusion](https://github.com/Runfusion/Fusion) - Multi node and multi platform agent orchestrator, supports missions, planning and more. Compatible with Paperclip, Hermes, OpenClaw. Built on Pi. ([runfusion.ai](https://runfusion.ai))
+- [Fusion](https://github.com/Runfusion/Fusion) - Multi-node, multi-platform agent orchestrator with a kanban board, plan-review-execute workflow gates, per-task git worktrees, and hierarchical missions.
 - [gastown](https://github.com/steveyegge/gastown) - Multi-agent orchestration system with persistent work tracking.
 - [gnap](https://github.com/farol-team/gnap) - Git-Native Agent Protocol: coordinate multiple agents via a shared git repo acting as a persistent task board (todo/doing/done), no orchestrator process required.
 - [guild](https://github.com/mathomhaus/guild) - Shared context, memory, and task coordination across AI coding agents. Single Go binary, local SQLite, hybrid keyword and semantic search.


### PR DESCRIPTION
Refines the existing **Fusion** entry under *Multi-Agent Swarms* for consistency with the rest of the list.

**Before**
> [fusion](https://github.com/Runfusion/Fusion) - Multi node and multi platform agent orchestrator, supports missions, planning and more. Compatible with Paperclip, Hermes, OpenClaw. Built on Pi. ([runfusion.ai](https://runfusion.ai))

**After**
> [Fusion](https://github.com/Runfusion/Fusion) - Multi-node, multi-platform agent orchestrator with a kanban board, plan-review-execute workflow gates, per-task git worktrees, and hierarchical missions.

Changes:
- Capitalizes the project name (**Fusion**) to match neighboring entries.
- Hyphenates "multi-node" / "multi-platform" and tightens to one factual sentence, matching the list's single-sentence style.
- Surfaces the concrete orchestration angle (kanban board, plan→review→execute gates, per-task git worktrees, hierarchical missions).
- Drops the trailing parenthetical site link, which no other entry in the section uses.

Verified against the repo and site: https://github.com/Runfusion/Fusion · https://runfusion.ai/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
