### PR TITLE
Add LoopTroop to autonomous loop runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Systems for coordinating multiple specialized agents working together.
 
 Projects implementing the "keep running until done" pattern.
 
+- [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for long-running AI coding tasks with LLM council planning, OpenCode execution in isolated git worktrees, and Ralph-style recovery loops that retry failed beads with fresh context.
 - [MartinLoop](https://github.com/Keesan12/martin-loop) - Control plane for AI coding agents with hard budget stops, verifier gates, rollback evidence, and inspectable run receipts.
 - [ralph-claude-code](https://github.com/frankbria/ralph-claude-code) - Autonomous AI development loop for Claude Code with intelligent exit detection.
 - [ralph-orchestrator](https://github.com/mikeyobrien/ralph-orchestrator) - Hat-based orchestration that keeps agents in a loop until done.


### PR DESCRIPTION
Adds [LoopTroop](https://github.com/looptroop-ai/LoopTroop) to Autonomous Loop Runners.

I checked the repo for `CONTRIBUTING.md` and a PR template through the GitHub community profile API. Neither is configured, so this follows the README's existing single-line format and keeps the change to one README insertion.

Why this section:
- LoopTroop's execution flow runs failed implementation beads through fresh-context Ralph-style recovery loops until they pass or hit retry limits.
- The LLM council is part of planning, but the runtime behavior maps most closely to the list's "keep running until done" category.
- Placed at the start of the section, before MartinLoop and the Ralph runners.