### PR TITLE
Add Agon

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Systems for coordinating multiple specialized agents working together.
 
 Projects implementing the "keep running until done" pattern.
 
+- [Agon](https://github.com/AutoResearch-Factory/Agon) - Autonomous research system that orchestrates scientist, coder, and auditor loops from topic to idea, proposal, and experiment.
 - [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for long-running AI coding tasks with LLM council planning, OpenCode execution in isolated git worktrees, and Ralph-style recovery loops that retry failed beads with fresh context.
 - [MartinLoop](https://github.com/Keesan12/martin-loop) - Control plane for AI coding agents with hard budget stops, verifier gates, rollback evidence, and inspectable run receipts.
 - [ralph-claude-code](https://github.com/frankbria/ralph-claude-code) - Autonomous AI development loop for Claude Code with intelligent exit detection.


### PR DESCRIPTION
Adds Agon to Autonomous Loop Runners.\n\nAgon is a prompt-based autonomous research system with scientist, coder, and auditor loops from topic to idea, proposal, and experiment.