### PR TITLE
docs: capitalize Emdash in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Tools for running multiple coding agents simultaneously on different tasks.
 - [crystal](https://github.com/stravu/crystal) - Run multiple Codex and Claude Code sessions in parallel git worktrees.
 - [dmux](https://github.com/standardagents/dmux) - Parallel agents with tmux and worktrees.
 - [dorothy](https://github.com/Charlie85270/Dorothy) - Desktop app to orchestrate multiple AI CLI agents with automations, Kanban management, and MCP servers.
-- [emdash](https://github.com/generalaction/emdash) - Run multiple coding agents in parallel.
+- [Emdash](https://github.com/generalaction/emdash) - Run multiple coding agents in parallel.
 - [ghast](https://github.com/aidenybai/ghast) - Multitask with multiple terminals.
 - [herdr](https://github.com/ogulcancelik/herdr) - Agent-aware terminal multiplexer with persistent workspaces, tabs, panes, and status detection for CLI coding agents.
 - [humanlayer](https://github.com/humanlayer/humanlayer) - Get AI coding agents to solve hard problems in complex codebases.


### PR DESCRIPTION
Thank you for the mention! 

## Summary

- Capitalize the Emdash product name in the README.
- Keep the repository URL unchanged.

## Verification

- `git diff --check`