### PR TITLE
Add sub-agents-skills to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Building blocks rather than runnable orchestrators: coordination protocols, sand
 - [neuralyzer](https://github.com/gintasz/neuralyzer) - Allow agent to wipe its own session context and re-run the first message. Easier and more ergonomic Ralph loop engineering.
 - [openfang](https://github.com/RightNow-AI/openfang) - Open-source Agent Operating System.
 - [skillfold](https://github.com/byronxlg/skillfold) - Configuration language and compiler for multi-agent AI pipelines. Compiles YAML config into agent skills for Claude Code, Cursor, Codex, Copilot, Gemini CLI, and Windsurf.
+- [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Runs sub-agents from portable Markdown definitions that encode task-specific instructions and execution choices—backend, model, effort, and permissions—for reuse across AI coding tools.
 
 ## Personal Assistants
 


### PR DESCRIPTION
Adds [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) to **Agent Infrastructure & Primitives**.

It runs reusable sub-agent definitions from Markdown across AI coding tools, preserving task-specific instructions and execution choices such as backend, model, effort, and permissions. It is placed here as a reusable orchestration primitive rather than a standalone swarm or autonomous task runner.

Disclosure: I maintain sub-agents-skills.