### PR TITLE
Add agent-console to Parallel Coding Agents - Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated list of tools and frameworks for orchestrating AI coding agents.
 
 Run and supervise multiple independent coding-agent sessions side-by-side from a terminal — tmux panes, git worktrees, and TUI/CLI dashboards.
 
+- [agent-console](https://github.com/buhuipao/agent-console) - Rust TUI that discovers Codex and Claude Code sessions from the providers' own transcripts, including ones started in other terminals, and groups them by workspace with working/waiting/idle/failed status. Resumes the provider's native UI instead of replacing it, keeps same-directory shells beside each agent, and requires neither tmux nor worktrees; on Unix a detached PTY daemon keeps managed sessions alive across dashboard restarts.
 - [agent-deck](https://github.com/asheshgoplani/agent-deck) - Terminal session manager for AI coding agents.
 - [agent-of-empires](https://github.com/njbrake/agent-of-empires) - A terminal session manager for AI coding agents on Linux and macOS.
 - [agentbox](https://github.com/madarco/agentbox) - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or cloud VMs via Hetzner/Daytona/Vercel/E2B) with sub-1s checkpoint starts. Works with Claude Code, Codex, and OpenCode.


### PR DESCRIPTION
Adding agent-console to Parallel Coding Agents — Terminal (TUI/CLI), inserted
alphabetically before agent-deck.

agent-console is a Rust TUI (ratatui + portable-pty) for Codex and Claude Code
sessions. Two things make it different from the tools already on this list:

- It discovers sessions from the providers' own persisted transcripts, so
  sessions started in any other terminal show up too, not only ones it launched.
- It does not require tmux or git worktrees. Managed sessions run in place and
  are guarded by cross-process leases; on Unix a detached PTY daemon keeps them
  alive across dashboard restarts.

Entering a session runs the provider's own resume command, so you get the native
Codex or Claude Code UI rather than a replacement chat interface. Each managed
agent can keep persistent same-directory shell panes beside it.

- Repo: https://github.com/buhuipao/agent-console
- crates.io: https://crates.io/crates/agent-console
- Licensed MIT OR Apache-2.0