### PR TITLE
Add ralphex

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Projects implementing the "keep running until done" pattern — a single goal dr
 - [ralph-claude-code](https://github.com/frankbria/ralph-claude-code) - Autonomous AI development loop for Claude Code with intelligent exit detection.
 - [ralph-orchestrator](https://github.com/mikeyobrien/ralph-orchestrator) - Hat-based orchestration that keeps agents in a loop until done.
 - [ralph-tui](https://github.com/subsy/ralph-tui) - Orchestrate AI coding agents to work through task lists autonomously.
+- [ralphex](https://github.com/umputun/ralphex) - Standalone CLI that orchestrates Claude Code or Codex to execute implementation plans autonomously, with fresh sessions per task, validation, retries, multi-phase review, and automatic commits.
 - [toryo](https://github.com/JesseRWeigel/toryo) - Intelligent agent orchestrator with trust-based delegation, quality ratcheting (git commit/revert), and Ralph Loop retries. Chains Claude Code, Aider, Gemini CLI, Ollama.
 
 ## Autonomous Task Runners


### PR DESCRIPTION
Adds [ralphex](https://github.com/umputun/ralphex) to **Autonomous Loop Runners**, in alphabetical order after `ralph-tui`.

ralphex is a standalone CLI that orchestrates Claude Code or Codex to execute implementation plans autonomously. It uses fresh sessions per task and includes validation, retries, multi-phase review, and automatic commits, matching the section's retry-until-verified pattern.
