### PR TITLE
Add Factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Unattended agents driven by an external source — an issue queue, a work board,
 - [claude-code-action](https://github.com/anthropics/claude-code-action) - Anthropic's official GitHub Action, detecting from context whether to answer, review, or implement. Auth via Anthropic API, Bedrock, Vertex, or Foundry.
 - [codex-action](https://github.com/openai/codex-action) - OpenAI's official GitHub Action, running Codex CLI headlessly under drop-sudo, unprivileged-user, or fully read-only sandboxes.
 - [cyrus](https://github.com/cyrusagents/cyrus) - Watches Linear, GitHub, GitLab, and Slack issues assigned to it, spinning up an isolated worktree per issue. Claude Code, Codex, Cursor, Gemini.
+- [Factory](https://github.com/owainlewis/factory) - Keeps coding agents working on a repository without making a human orchestrate every step from a terminal, pulling tasks from trusted ticket queues into isolated Codex workspaces.
 - [gh-aw](https://github.com/github/gh-aw) - Compiles agentic workflows written in Markdown into GitHub Actions YAML. Read-only by default, with writes only through sanitized safe-outputs. Copilot, Claude, Codex, Gemini.
 - [lalph](https://github.com/tim-smart/lalph) - Orchestrator driven by whichever source of issues you point it at.
 - [multica](https://github.com/multica-ai/multica) - Managed agents platform where you assign tasks, track progress, and let agents compound skills between runs.


### PR DESCRIPTION
Adds [Factory](https://github.com/owainlewis/factory) to **Autonomous Task Runners**, in alphabetical order between `cyrus` and `gh-aw`.

Factory keeps coding agents working on a repository without making a human orchestrate every step from a terminal. It watches trusted ticket queues and schedules, creates durable tasks, prepares isolated Codex workspaces, and keeps work moving toward human-reviewed pull requests.
