### PR TITLE
Add Ouijit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [nimbalyst](https://github.com/nimbalyst/nimbalyst) - Visual workspace pairing parallel worktree sessions with kanban and direct visual editing. Claude Code, Codex, OpenCode.
 - [octomux](https://github.com/ShreyPaharia/octomux) - Local dashboard with a kanban fleet view, one unified permission inbox across agents, and in-app diff review.
 - [Orca](https://github.com/stablyai/orca) - Agentic development environment for running a fleet on your own subscription, available on desktop and mobile.
+- [Ouijit](https://github.com/ouijit/ouijit) - Kanban board and terminals wired together by lifecycle hooks, scripts, and a session-aware CLI, so a task runs by hand, on a script, or delegated to the agent. Per-task worktrees, optional VM sandboxing. Claude Code, Codex, Pi, OpenCode.
 - [parallel-code](https://github.com/johannesjo/parallel-code) - Desktop app running Claude Code, Codex, and Gemini CLI side by side in isolated worktrees, with a built-in diff viewer and one-click merge.
 - [Proliferate](https://github.com/proliferate-ai/proliferate) - Agent IDE that runs sessions locally or in the cloud and lets you build reusable workflows from them.
 - [supacode](https://github.com/supabitapp/supacode) - Native macOS command center for worktree-per-agent development.


### PR DESCRIPTION
Ouijit is a task and terminal session manager I built for running agent CLIs in parallel. Each task gets a git worktree and its own terminals, and lifecycle hooks, scripts, and a CLI available inside every terminal decide what actually runs, so a task can be driven by hand or handed off to the agent. Optional VM sandboxing per session via Lima or nono.

macOS and Linux, AGPL-3.0, no account or telemetry. https://ouijit.com