### PR TITLE
Add Fletch to Parallel Coding Agents - Desktop & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [constellagent](https://github.com/owengretzinger/constellagent) - macOS app giving each agent its own terminal, editor, and git worktree in a single window.
 - [dorothy](https://github.com/Charlie85270/Dorothy) - Desktop app combining agent orchestration with automations, Kanban management, and MCP servers.
 - [Emdash](https://github.com/generalaction/emdash) - Agentic development environment running parallel agents against any model provider.
+- [Fletch](https://github.com/fwdai/fletch) - Native macOS IDE that seals each agent in its own repo clone under Seatbelt or Docker, serves each a shared symbol and call-graph index over MCP, and gates every step on tests or your approval. Claude Code, Codex, Cursor, OpenCode.
 - [Garcon](https://github.com/cfal/garcon) - Self-hosted browser and mobile workspace with diff review, Git/PR workflows, mobile approvals, scheduling, and cross-agent transfers. Seven CLI agents.
 - [humanlayer](https://github.com/humanlayer/humanlayer) - Human-in-the-loop control for coding agents on hard problems; the repo notes its code is now largely deprecated in favor of a rebuild.
 - [IM.codes](https://github.com/im4codes/imcodes) - Mobile and web control layer built for away-from-desk continuation, with terminal access, git views, localhost preview, and scheduled tasks. Claude Code, Codex, Gemini CLI.


### PR DESCRIPTION
Adds [Fletch](https://github.com/fwdai/fletch), a native macOS IDE for running coding agents, to **Parallel Coding Agents — Desktop & Web**.

```
- [Fletch](https://github.com/fwdai/fletch) - Native macOS IDE that seals each agent in its own repo clone under Seatbelt or Docker, serves each a shared symbol and call-graph index over MCP, and gates every step on tests or your approval. Claude Code, Codex, Cursor, OpenCode.
```

**On scope.** Fletch sandboxes agents and serves them an index over MCP, so it could be misread as one of the sandbox providers or MCP servers the list excludes. It is the other side of that line: it decides what each agent works on, where it runs, and what happens to the diff, and it takes whatever task you point it at. The sandbox and the index are things it builds for agents, not things it is.

**Placement.** Desktop & Web rather than Terminal, since it is a GUI app with diff review and merge. Inserted alphabetically between Emdash and Garcon.

**What is different about it,** since the section header already covers parallel sessions and diff review:

- Each agent gets its own `git clone --shared` with its own writable `.git`, inside a macOS Seatbelt sandbox or its own Docker container, rather than a worktree sharing one `.git`. Your working copy is never writable by an agent.
- A symbol and call-graph index of the repo is served to every agent over MCP, built in a throwaway mirror so nothing is written to the source repo. Agents navigate structure instead of grepping for it.
- Workflow steps advance on verifiable conditions, meaning tests passing, a commit landing, or human approval, with budgets for turns, tokens and wall-clock enforced by the engine rather than requested in a prompt.
- Push and pull requests run host-side through a brokered transport, so credentials never enter a sandbox.

Details: macOS 13+, universal, AGPL-3.0, free, drives the agent CLIs you already have rather than proxying any model. It is in public beta and the known limitations are on the [FAQ](https://fletch.sh/docs/reference/faq/).

Disclosure: I am the author. Happy to reword or shorten the entry if it runs long for the section.
