### PR TITLE
Add `cc-autopilot` to Autonomous Loop Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Systems where multiple specialized agents actively coordinate, communicate, and 
 The "keep running until done" pattern — a single goal driven through a retry-until-verified loop.
 
 - [bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Keeps no model in the coordination loop, so orchestration costs zero tokens. Verifies with tests and auto-commits across 40+ CLI agents.
+- [cc-autopilot](https://github.com/gbotev1/cc-autopilot) - Perpetual quality loop whose judge panel audits the project, files its own work, and refills the board when it drains. Sole-writer fixers own file-disjoint slices proven by construction, and nothing commits without passing live verification, with failures reverted. Claude Code.
 - [Dex](https://github.com/francescoalemanno/dex) - Human-gated planning, multi-reviewer code review, and dead-end-aware research loops, shipped as cross-platform binaries for 7 CLI backends.
 - [fractal](https://github.com/plasma-ai/fractal) - Loops that recursively delegate separable subtasks to child agents, bounded by configurable depth, cost, and time limits.
 - [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - An LLM council plans the work, then Ralph-style loops retry failed units with fresh context. Executes via OpenCode worktrees.


### PR DESCRIPTION
Adds [cc-autopilot](https://github.com/gbotev1/cc-autopilot), a perpetual autonomous loop for Claude Code that holds a project to an authored quality bar. A panel of judge agents audits the project and files its own work; fixers each own a file-disjoint slice of the tree (proven by construction, so two agents can never touch the same file); every change is verified live (browser for web apps, gate suite for CLIs/libraries) and reverted on failure before anything commits.

Placed in Autonomous Loop Runners since it uses the keep-running, verify-or-revert pattern (nearest neighbors: `toryo`, `kodo`, `ralphex`). It also straddles Multi-Agent Swarms via the judge panel plus synthesizer, so feel free to re-shelve if you see it differently.

Disclosure: I'm the author.