### PR TITLE
Add Traycer to Parallel Coding Agents — Desktop & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [takopi](https://github.com/banteg/takopi) - Telegram bridge that puts Codex, Claude Code, OpenCode, and Pi sessions in a chat thread.
 - [Tempest](https://github.com/tempestai-dev/tempest) - Tauri desktop ADE running CLI agents in parallel isolated worktrees, with a shared local code-knowledge graph that cuts token use across sessions, plus live status and built-in diff/PR review.
 - [tlbx](https://github.com/tlbx-ai/tlbx) - Self-hosted browser workspace holding persistent real PTY sessions on your own machines, reachable from any browser or phone.
+- [Traycer](https://github.com/traycerai/traycer) - Bring-your-own-agent workspace running many sessions in parallel with context shared across models and providers, plus agent-to-agent messaging, shareable boards, and cross-device sync.
 - [vibe-tree](https://github.com/sahithvibudhi/vibe-tree) - One git worktree per agent, delivered as desktop, web, and CLI.
 - [vibecraft](https://github.com/rayzhudev/vibecraft) - RTS-style workspace for commanding coding agents.
 


### PR DESCRIPTION
Adds [Traycer](https://github.com/traycerai/traycer) (open-source AI orchestration app, MIT, ~1k★, actively maintained) to the Desktop & Web section.

Traycer runs multiple coding agents in parallel with context shared across models/providers (BYOA), plus agent-to-agent messaging, shareable boards, real-time collaboration, and cross-device sync. Placed in Desktop & Web as a GUI workspace for parallel agent sessions.