### PR TITLE
Add Claim Plane to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [agent-runbook](https://github.com/KnoxOps/agent-runbook) - Compiles YAML runbooks with loops, branching, and parallelism into SKILL.md files for Claude Code and Codex.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Keeps specialist agents in a hub and spins up a temporary orchestrator per task, with A2A routing and governed memory gates. Formerly Hephaestus.
 - [agenttier](https://github.com/agenttier/agenttier) - Kubernetes runtime giving each agent its own Pod and PVC sandbox behind a default-deny NetworkPolicy, with a streaming SSE invoke API.
+- [Claim Plane](https://github.com/SkeinRank/claim-plane) - Authority and evidence control plane for coding agents that turns proposed scope into bounded mutation authority, blocks undeclared writes before mutation, records controlled amendments, and independently verifies final delivery. Codex.
 - [Claudexor](https://github.com/razzant/claudexor) - Routes one coding thread across harnesses with quota-aware rotation between subscription profiles, Best-of-N runs, and cross-family review.
 - [codecast](https://github.com/codecast-sh/codecast) - Watches your real local sessions and surfaces them in a live triage inbox, keeping a searchable record with line-level agent attribution. Claude Code, Codex, Cursor, Gemini.
 - [guild](https://github.com/mathomhaus/guild) - Shared context, memory, and task coordination as a single Go binary over local SQLite with hybrid keyword and semantic search.


### PR DESCRIPTION
## Summary

Adds Claim Plane to the Agent Infrastructure & Primitives section.

Claim Plane is an open-source authority and evidence control plane for coding agents. It turns proposed task scope into bounded mutation authority, blocks undeclared writes before mutation, records controlled scope amendments, and independently verifies final delivery.

## Why it fits

This section covers control planes, coordination protocols, harness adapters, and runtimes beneath agents.

Claim Plane operates as a runtime control layer around coding agents rather than as another coding agent or user-facing orchestration interface. Its current public technical preview integrates with Codex CLI.

- Repository: https://github.com/SkeinRank/claim-plane
- License: Apache-2.0
