### PR TITLE
Add Agent Island to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Unattended agents driven by an external source — an issue queue, a work board,
 Control planes, coordination protocols, harness adapters, and runtimes — the layer beneath your agents rather than the surface you work in.
 
 - [agent-runbook](https://github.com/KnoxOps/agent-runbook) - Compiles YAML runbooks with loops, branching, and parallelism into SKILL.md files for Claude Code and Codex.
+- [Agent Island](https://github.com/tristan666666/agent-island) - Menu bar and notch companion surfacing live session state and your-turn alerts, with quota and cost computed locally on your own machine. Claude Code, Codex, Gemini, Grok, Cursor.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Keeps specialist agents in a hub and spins up a temporary orchestrator per task, with A2A routing and governed memory gates. Formerly Hephaestus.
 - [agenttier](https://github.com/agenttier/agenttier) - Kubernetes runtime giving each agent its own Pod and PVC sandbox behind a default-deny NetworkPolicy, with a streaming SSE invoke API.
 - [Archon](https://github.com/coleam00/Archon) - Harness builder for deterministic AI coding workflows, combining agent steps with scripts, validation gates, approvals, and isolated git worktrees. Claude Code, Codex, and more.


### PR DESCRIPTION
Adds **Agent Island** to `## Agent Infrastructure & Primitives`, in alphabetical position.

It sits in the same layer as [codecast](https://github.com/codecast-sh/codecast) — it watches real local sessions rather than being a surface you work in. Agent Island reads the transcript files the CLIs already write to disk, derives per-session state (working / stalled / your turn), raises an alert when a run is waiting on you, and computes quota and cost locally.

- Providers: Claude Code, Codex, Gemini, Grok, Cursor
- Native macOS and Windows apps, MIT licensed
- Local-first: no account, no product telemetry

Site: https://agent-island.dev