### PR TITLE
Add Podiom to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [neuralyzer](https://github.com/gintasz/neuralyzer) - Lets an agent wipe its own session context and re-run the first message, making Ralph loops easier to engineer.
 - [omnigent](https://github.com/omnigent-ai/omnigent) - Meta-harness running Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, or custom YAML agents against swappable sandbox backends, with policy enforcement.
 - [openfang](https://github.com/RightNow-AI/openfang) - Open-source agent operating system.
+- [Podiom](https://github.com/Podiom/Podiom) - Local-first control plane for Claude Code and Codex CLI agents: durable named agents, sessions that survive provider/profile switches, a shared project ledger, and built-in scheduling, in a single Go binary with an embedded web UI.
 - [sandbox-agent](https://github.com/rivet-dev/sandbox-agent) - Daemon, HTTP/SSE API, and TypeScript SDK for driving six coding agents inside E2B, Daytona, Modal, Cloudflare Containers, or Docker.
 - [skillfold](https://github.com/byronxlg/skillfold) - Declares skills in YAML and pins exact revisions in a lockfile so installs are reproducible across Claude Code and Codex.
 - [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Portable Markdown definitions that route a task to a chosen backend, model, effort level, and permission set.


### PR DESCRIPTION
Adds [Podiom](https://github.com/Podiom/Podiom) to Agent Infrastructure & Primitives, alphabetically between openfang and sandbox-agent.

Podiom is a local-first control plane for Claude Code and Codex CLI agents: it shells out to the native CLIs (keeping their MCP/tools/skills) while owning durable named agents, chat sessions that survive provider/profile switches, a shared project ledger across agents, and a built-in scheduler. Ships as a single Go binary with an embedded Svelte web UI. MIT licensed.

Disclosure: I'm the author. This is a young project (~6 weeks old, 2 stars) but has real external usage — 4 forks and 3 merged pull requests from unaffiliated contributors who found it through good-first-issue labels, no paid/bot promotion involved.

Happy to adjust placement or wording to match the list's conventions.