### PR TITLE
Add Zaivern Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [vibe-tree](https://github.com/sahithvibudhi/vibe-tree) - One git worktree per agent, delivered as desktop, web, and CLI.
 - [vibecraft](https://github.com/rayzhudev/vibecraft) - RTS-style workspace for commanding coding agents.
 - [Waku](https://github.com/egoist/waku) - Native macOS desktop app for working with local coding agents, keeping projects, sessions, and transcripts on your machine. Supports Amp, Claude Code, Codex CLI, Cursor CLI, Grok Build, OpenCode, and Pi.
+- [Zaivern Code](https://github.com/tacyan/zaivern-code) - Cross-platform Rust desktop cockpit for running Claude Code, Codex, Gemini CLI, and 30+ coding agents in parallel, with fleet monitoring, mobile control, and line-level ownership to prevent merge conflicts.
 
 ## Multi-Agent Swarms
 


### PR DESCRIPTION
Adds [Zaivern Code](https://github.com/tacyan/zaivern-code) to the “Parallel Coding Agents — Desktop & Web” section.

Zaivern Code is an open-source, cross-platform Rust desktop cockpit for running and monitoring multiple AI coding tools, including Claude Code, Codex, and Gemini CLI.

It supports parallel agent sessions, fleet monitoring, mobile control, an integrated editor, and line-level ownership for reducing merge conflicts.

Disclosure: I am the project maintainer.