### PR TITLE
Add LongHorizon-Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [guild](https://github.com/mathomhaus/guild) - Shared context, memory, and task coordination as a single Go binary over local SQLite with hybrid keyword and semantic search.
 - [handoff](https://github.com/dazuiba/handoff) - Delegates a task to DeepSeek, Codex, or Claude from inside your current Claude Code or Codex session, returning the result automatically.
 - [LionClaw](https://github.com/moshthepitt/lionclaw) - Local control plane running coding agents as durable, auditable workers with explicit state, skills, and checkpoints.
+- [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness) - Coordinates manager, fresh-context executor, and independent auditor roles over long-running GUI and CLI tasks, preserving verified progress across rounds. Claude Code, Codex, and OpenClaw.
 - [NemoClaw](https://github.com/NVIDIA/NemoClaw) - Runs Hermes, LangChain Deep Agents, and OpenClaw inside NVIDIA OpenShell with managed inference.
 - [neuralyzer](https://github.com/gintasz/neuralyzer) - Lets an agent wipe its own session context and re-run the first message, making Ralph loops easier to engineer.
 - [omnigent](https://github.com/omnigent-ai/omnigent) - Meta-harness running Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, or custom YAML agents against swappable sandbox backends, with policy enforcement.


### PR DESCRIPTION
## What changed

- Add LongHorizon-Harness to **Agent Infrastructure & Primitives**.

## Why it fits

LongHorizon-Harness coordinates manager, fresh-context executor, and independent auditor roles for long-running GUI and CLI tasks. Its durable verified-state model and harness integrations place it in the control-plane and runtime layer described by this section.

## Validation

- Confirmed the project is public, active, and not already listed.
- Checked open and closed pull requests for an existing LongHorizon-Harness submission.
- Kept the existing one-line format and alphabetical placement.
