### PR TITLE
[i18n] Add Translations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A curated list of tools and frameworks for orchestrating agents.
 
 Everything here decides what an agent works on, when it runs, where it runs, or what happens to its output, and takes whatever task you point it at. Single-purpose bots, and things an agent merely consumes — memory backends, MCP servers, sandbox providers, skill libraries — are out of scope.
 
+## Translations
+
+- [Português (Brasil)](README.pt-BR.md)
+
 ## How to choose
 
 - **Run several agents at once and review each diff.** [Terminal](#parallel-coding-agents--terminal-tuicli) if you live in tmux, [Desktop & Web](#parallel-coding-agents--desktop--web) if you want a GUI or phone access.


### PR DESCRIPTION
## Summary

Adds a "Translations" section to the README pointing to the Brazilian Portuguese translation added in https://github.com/andyrewlee/awesome-agent-orchestrators/pull/149.

## Files

- `README.md` — new "Translations" section after the intro paragraph, listing `README.pt-BR.md`.

## Notes

- Merge recommended after PR #149 (the link points to a file created in that PR).
- No other changes to the README.