### PR TITLE
Add lienox (parallel coding agents — desktop & web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [jat](https://github.com/joewinke/jat) - Visual dashboard combining live sessions, task management, code editor, and terminal, with parallel swarm workflows.
 - [jean](https://github.com/coollabsio/jean) - Desktop and web app for orchestrating agents across multiple projects and their git worktrees. Claude, Codex, OpenCode.
 - [kandev](https://github.com/kdlbs/kandev) - Kanban workbench whose multi-step workflows assign a different agent per step behind human gates, running locally, in Docker, over SSH, or in cloud executors.
+- [lienox](https://lienox.com) - Cross-platform desktop app running parallel agents across projects, with a verification kanban, in-app scheduling, a per-agent browser, and phone remote. BYOK — Claude Code, Codex, OpenCode, Kimi, OpenRouter, NVIDIA, and local models via Ollama.
 - [mux](https://github.com/coder/mux) - Desktop app for isolated, parallel agentic development.
 - [nimbalyst](https://github.com/nimbalyst/nimbalyst) - Visual workspace pairing parallel worktree sessions with kanban and direct visual editing. Claude Code, Codex, OpenCode.
 - [octomux](https://github.com/ShreyPaharia/octomux) - Local dashboard with a kanban fleet view, one unified permission inbox across agents, and in-app diff review.


### PR DESCRIPTION
Adds **lienox** to *Parallel Coding Agents — Desktop & Web*.

It is a cross-platform desktop app (Linux, Windows, macOS) that runs several coding
agents in parallel across projects in one window. What sets it apart from the other
entries in this section:

- **Cross-platform**, not macOS-only.
- **BYOK, multi-agent, multi-provider**: you bring your own access and pay the provider
  directly — Claude Code, Codex, OpenCode and Kimi through the subscription you already
  pay for (no key to paste), OpenRouter and NVIDIA with your own API key, or local
  models via Ollama with no key at all. Different nodes of one flow can run on
  different models, and there is no credit meter in between.
- **A kanban board with a verification gate** — an agent has to check each acceptance
  criterion with a real tool before a card can move to done.
- **Scheduling built in**: recurring agent runs without cron, a server or a CI action.
- Also a browser per agent (isolated tab), local voice control, and remote control
  from a phone.

Closed source, free tier available, no account required to run it — everything stays
on the user's machine. Happy to reword or move it if another section fits better.