### PR TITLE
Add Waku to Parallel Coding Agents — Desktop & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [Traycer](https://github.com/traycerai/traycer) - Bring-your-own-agent workspace running many sessions in parallel with context shared across models and providers, plus agent-to-agent messaging, shareable boards, and cross-device sync.
 - [vibe-tree](https://github.com/sahithvibudhi/vibe-tree) - One git worktree per agent, delivered as desktop, web, and CLI.
 - [vibecraft](https://github.com/rayzhudev/vibecraft) - RTS-style workspace for commanding coding agents.
+- [Waku](https://github.com/egoist/waku) - Native macOS desktop app for working with local coding agents, keeping projects, sessions, and transcripts on your machine. Supports Amp, Claude Code, Codex CLI, Cursor CLI, Grok Build, OpenCode, and Pi.
 
 ## Multi-Agent Swarms
 


### PR DESCRIPTION
## Summary

- Add Waku to the Parallel Coding Agents — Desktop & Web category.
- Waku is a native macOS workspace for local coding agents, supporting Amp, Claude Code, Codex CLI, Cursor CLI, Grok Build, OpenCode, and Pi.

## Eligibility

- Public GitHub repository with an open-source GPL-3.0 license.
- 575+ GitHub stars at review time.
- Fits the desktop/web coding-agent workspace category.

## Validation

- git diff --check