### PR TITLE
Add OpenChamber to Parallel Coding Agents — Desktop & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [mux](https://github.com/coder/mux) - Desktop app for isolated, parallel agentic development.
 - [nimbalyst](https://github.com/nimbalyst/nimbalyst) - Visual workspace pairing parallel worktree sessions with kanban and direct visual editing. Claude Code, Codex, OpenCode.
 - [octomux](https://github.com/ShreyPaharia/octomux) - Local dashboard with a kanban fleet view, one unified permission inbox across agents, and in-app diff review.
+- [OpenChamber](https://github.com/openchamber/openchamber) - Open-source workspace for running, supervising, and reviewing AI coding work across desktop, browser, editor, and mobile, with parallel model runs and per-run worktrees.
 - [Orca](https://github.com/stablyai/orca) - Agentic development environment for running a fleet on your own subscription, available on desktop and mobile.
 - [Ouijit](https://github.com/ouijit/ouijit) - Kanban board and terminals wired together by lifecycle hooks, scripts, and a session-aware CLI, so a task runs by hand, on a script, or delegated to the agent. Per-task worktrees, optional VM sandboxing. Claude Code, Codex, Pi, OpenCode.
 - [parallel-code](https://github.com/johannesjo/parallel-code) - Desktop app running Claude Code, Codex, and Gemini CLI side by side in isolated worktrees, with a built-in diff viewer and one-click merge.


### PR DESCRIPTION
## Summary

- Add OpenChamber to the Parallel Coding Agents — Desktop & Web category.
- OpenChamber is an open-source workspace for supervising and reviewing coding-agent work across desktop, web, editor, and mobile, with parallel model runs and per-run worktrees.

## Eligibility

- Public GitHub repository with an open-source MIT license.
- 8.6k+ GitHub stars at review time.
- Fits the desktop/web coding-agent workspace category.

## Validation

- git diff --check