### PR TITLE
Add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) - TypeScript-native runtime where a coordinator turns a goal into a task DAG and a deterministic scheduler runs specialized agents, with approvals, traces, evaluation, checkpoints, and resume support.
 - [openfang](https://github.com/RightNow-AI/openfang) - Open-source agent operating system.
 - [sandbox-agent](https://github.com/rivet-dev/sandbox-agent) - Daemon, HTTP/SSE API, and TypeScript SDK for driving six coding agents inside E2B, Daytona, Modal, Cloudflare Containers, or Docker.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Local-first TypeScript agent runtime with persistent sessions, sandboxed tools, memory, audit and replay, plus an MCP bridge and native DeepSeek Harness bundle.
 - [skillfold](https://github.com/byronxlg/skillfold) - Declares skills in YAML and pins exact revisions in a lockfile so installs are reproducible across Claude Code and Codex.
 - [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Portable Markdown definitions that route a task to a chosen backend, model, effort level, and permission set.
 


### PR DESCRIPTION
## Summary

Add [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) to **Agent Infrastructure & Primitives**.

It fits this section as a local-first TypeScript agent runtime with persistent sessions, sandboxed tools, memory, audit/replay, an MCP bridge, and a native DeepSeek Harness bundle. The change is a single alphabetized entry and does not add generated files or unrelated edits.

## Verification

- Confirmed the linked repository is public and Apache-2.0 licensed
- Confirmed the listed capabilities against the project README and repository description
- `git diff --check` passes

## Disclosure

I am affiliated with SandBase AI and am submitting this entry on behalf of the project.