### PR TITLE
Add Berd to Parallel Coding Agents — Desktop & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [Aperant](https://github.com/AndyMik90/Aperant) - Runs up to 12 agent terminals with a self-validating QA loop and automatic conflict resolution when merging back to main.
 - [automaker](https://github.com/AutoMaker-Org/automaker) - Describe features on a Kanban board and agents implement them in isolated worktrees, running tests and committing as they go.
 - [bb](https://github.com/get-bb/bb) - Self-controlling agentic IDE that orchestrates multiple coding agents in live threads you can follow, steer, or hand off, driven from a desktop app, web app, CLI, or HTTP API.
+- [Berd](https://github.com/block/berd) - Block's open-source desktop app for working with AI agents: project chats with per-folder worktree behavior over the Goose backend, with agents, skills, connections, and agent sharing in one place.
 - [Better Agent](https://github.com/ofekron/better-agent) - Local web workspace with persistent state, approvals, and restart recovery for native Claude, Codex, and Gemini sessions.
 - [Claude Command Center (CCC)](https://github.com/amirfish1/claude-command-center) - Local dashboard for spawning, monitoring, and resuming sessions across Claude Code, Codex, Cursor, Antigravity, and Kilo Code.
 - [clave](https://github.com/codika-io/clave) - Native macOS app with split and grid layouts, session groups, SSH remote sessions, and usage analytics for Claude Code.


### PR DESCRIPTION
Adds [Berd](https://github.com/block/berd) to **Parallel Coding Agents — Desktop & Web**, alphabetically between `bb` and `Better Agent`.

Berd is Block's open-source Tauri desktop app for working with AI agents: project chats with per-folder worktree behavior over the Goose backend, with agents, skills, connections, and agent sharing in one place.

- 478 stars, Apache-2.0, actively developed (first public release v0.6.0 on 2026-08-14)
- Fits the section's scope: the parallel-sessions workflow delivered as a desktop app

Note: the remote `updates` branch was stale (its only commit was already in main via #96, verified by patch-id), so it was reset to main before adding this commit.