### PR TITLE
Add CONTRIBUTING.md and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## New listing
+
+- [ ] Fits the inclusion criteria (orchestrates agents — not a standalone MCP server, sandbox, memory backend, skill library, or single-purpose bot)
+- [ ] Not a duplicate of an existing README entry (including Resting)
+- [ ] One-line entry is alphabetized in the correct section
+- [ ] Description is concrete (what it decides / runs / reviews)
+
+### Proposed category
+
+<!-- Pick one -->
+- [ ] Parallel Coding Agents — Terminal (TUI/CLI)
+- [ ] Parallel Coding Agents — Desktop & Web
+- [ ] Multi-Agent Swarms
+- [ ] Autonomous Loop Runners
+- [ ] Autonomous Task Runners
+- [ ] Agent Infrastructure & Primitives
+- [ ] Personal Assistants
+
+### Draft README line
+
+```markdown
+- [name](https://github.com/owner/repo) - …
+```
+
+### Why this is an orchestrator
+
+<!-- 2–3 sentences: what it decides (work / when / where / output), and that it takes arbitrary tasks -->
+
+
+
+### Freshness signal
+
+<!-- e.g. last push date, or "active as of YYYY-MM" -->
+
+
+### Extra notes (optional)
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Thanks for helping keep this list useful. We curate **agent orchestrators** — tools that decide what an agent works on, when it runs, where it runs, or what happens to its output, and take whatever task you point them at.
+
+If you're unsure whether something belongs, skim [How to choose](README.md#how-to-choose) and open an issue first.
+
+## What belongs here
+
+**In scope**
+
+- Parallel session managers (terminal, desktop, or web)
+- Autonomous loop / task runners that keep agents working without babysitting
+- Multi-agent swarms that split work across agents
+- Personal assistants that stay running, remember across sessions, and pick up work from chat
+- Infrastructure and primitives that act as control planes, coordination protocols, harness adapters, or runtimes for orchestration
+
+**Out of scope** (please don't open a PR for these alone)
+
+- Single-purpose bots
+- Memory backends, MCP servers, sandbox providers, or skill libraries as standalone products
+- Things an agent merely *consumes* rather than a surface that *orchestrates* agents
+
+## Categories
+
+Pick one section (use these exact names):
+
+| Category | Use when |
+| --- | --- |
+| Parallel Coding Agents — Terminal (TUI/CLI) | Side-by-side coding agents from a terminal (tmux, worktrees, TUI dashboards) |
+| Parallel Coding Agents — Desktop & Web | Same idea as a desktop app or browser/mobile dashboard |
+| Multi-Agent Swarms | Agents split a large job between themselves |
+| Autonomous Loop Runners | One goal, driven until verified |
+| Autonomous Task Runners | Work pulled from an issue tracker, board, or schedule |
+| Agent Infrastructure & Primitives | Control planes, protocols, harness adapters, runtimes |
+| Personal Assistants | Always-on chat/desktop agents; general tasks, not only code |
+
+**Resting** is maintainer-managed. Don't submit new entries there — it's a watchlist for projects without recent pushes.
+
+## How to add an entry
+
+1. Fork the repo and create a branch.
+2. Add **one** line to the right section of `README.md`, alphabetized by name:
+
+   ```markdown
+   - [project-name](https://github.com/owner/repo) - Short description of what it orchestrates and how.
+   ```
+
+3. Keep the description concrete (what it decides / runs / reviews), not marketing fluff.
+4. Open a PR using the template. Fill in why it is an orchestrator, which category, and a freshness signal (recent push or last-commit month).
+
+## PR quality bar
+
+We'll look for:
+
+- Clear fit to the inclusion criteria (not adjacent tooling)
+- Correct category and alphabetical placement
+- No duplicate of an existing listing (including Resting)
+- A real public repo with enough signal to evaluate (README, activity)
+
+PRs that are a bulk dump of many tools, or that only wrap an MCP/sandbox/memory product, will usually be closed with a pointer back here.
+
+## Questions
+
+Open an issue if the category is ambiguous or you want a maintainer take before writing the PR.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A curated list of tools and frameworks for orchestrating agents.
 
 Everything here decides what an agent works on, when it runs, where it runs, or what happens to its output, and takes whatever task you point it at. Single-purpose bots, and things an agent merely consumes — memory backends, MCP servers, sandbox providers, skill libraries — are out of scope.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for inclusion criteria, categories, and the PR checklist.
+
 ## How to choose
 
 - **Run several agents at once and review each diff.** [Terminal](#parallel-coding-agents--terminal-tuicli) if you live in tmux, [Desktop & Web](#parallel-coding-agents--desktop--web) if you want a GUI or phone access.


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` with tight inclusion criteria, out-of-scope rejection examples, category guide, and entry format
- Adds `.github/PULL_REQUEST_TEMPLATE.md` checklist for listing PRs
- Links Contributing from the README (no listing/content ads)

## Why
Cuts noise on the ~20 open listing PRs and raises submission quality. Soft Checkfu / no README ads unchanged.

## Test plan
- [ ] Preview CONTRIBUTING and template on GitHub
- [ ] Confirm new PR form shows the template checkboxes