### PR TITLE
Add Vibestrate to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [sandbox-agent](https://github.com/rivet-dev/sandbox-agent) - Daemon, HTTP/SSE API, and TypeScript SDK for driving six coding agents inside E2B, Daytona, Modal, Cloudflare Containers, or Docker.
 - [skillfold](https://github.com/byronxlg/skillfold) - Declares skills in YAML and pins exact revisions in a lockfile so installs are reproducible across Claude Code and Codex.
 - [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Portable Markdown definitions that route a task to a chosen backend, model, effort level, and permission set.
+- [Vibestrate](https://github.com/guyshonshon/vibestrate) - Runs one task through a YAML flow of seated phases, giving every seat the same project rules, auto-derived codebase map, and running brief, while the reviewer starts a fresh process rather than inheriting the writer's session. Approval gates, a git worktree per run, and a local token and cost ledger. Claude Code, Codex, Gemini CLI, OpenCode, Aider, Cursor CLI, Amp, Goose, Crush, Qwen Code, Ollama.
 
 ## Personal Assistants
 


### PR DESCRIPTION
Adds [Vibestrate](https://github.com/guyshonshon/vibestrate), an Apache-2.0 local-first orchestrator for coding agents.

Placed under **Agent Infrastructure & Primitives** rather than either Parallel Coding Agents section: it is a sequential supervised pipeline, not a parallel session manager. Its nearest neighbours in the list are Archon, Crewplane and omnigent.

What it does that is not already covered there: a run is a YAML flow of seated phases, and every seat is handed the same project rules, auto-derived codebase map, roadmap and running brief, so context is not re-established per agent. The reviewer seat starts a fresh process and never inherits the implementer's session, so it reads the diff cold. Approval gates, a git worktree per run, and a local token/cost/decision ledger.

Eleven agent CLIs are built in: Claude Code, Codex, Gemini CLI, OpenCode, Aider, Cursor CLI, Amp, Goose, Crush, Qwen Code, and local models via Ollama. No cloud component and no telemetry.

Disclosure: I am the author.

Site: https://vibestrate.com