### PR TITLE
Add Taskuary

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Unattended agents driven by an external source — an issue queue, a work board,
 - [run-gemini-cli](https://github.com/google-github-actions/run-gemini-cli) - Google's official GitHub Action, running on event or schedule triggers or on demand via `@gemini-cli /review` and `/triage`.
 - [sortie](https://github.com/sortie-ai/sortie) - Turns tracker tickets into agent sessions. Agent-agnostic and tracker-agnostic, as a single Go binary with SQLite persistence.
 - [symphony](https://github.com/openai/symphony) - Turns project work into isolated autonomous runs, so teams manage the work rather than supervise the agent.
+- [Taskuary](https://github.com/ldbumble/taskuary) - Local-first work inbox that triages email, chat, issue trackers, and scheduled reports into supervised Claude Code, Codex, Gemini, Cursor, or Copilot CLI runs, with conflict-aware queuing, live terminals, and approval-gated replies.
 
 ## Agent Infrastructure & Primitives
 


### PR DESCRIPTION
https://github.com/ldbumble/taskuary
Taskuary fits Autonomous Task Runners because it watches email, chat, issue trackers, and schedules; triages inbound work; dispatches it to the users existing coding CLIs; queues likely file collisions; exposes live terminals; and keeps outbound replies behind human approval. It is MIT-licensed, local-first, and actively maintained. 
Disclosure: I maintain Taskuary.