### PR TITLE
Add Rakazo to Personal Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Always-on agents you reach over chat or a desktop app. They remember across sess
 - [Ouroboros](https://github.com/razzant/ouroboros) - General-purpose agent with durable identity and memory, reviewed self-modification, multi-agent coordination, and desktop and headless interfaces.
 - [picoclaw](https://github.com/sipeed/picoclaw) - Tiny and fast assistant deployable anywhere.
 - [QwenPaw](https://github.com/agentscope-ai/QwenPaw) - Personal assistant that deploys to your own machine or the cloud and plugs into multiple chat apps. Formerly CoPaw.
+- [Rakazo](https://github.com/elie222/rakazo) - Self-hosted platform for persistent AI teammates with their own conversations, memory, and routines, running on shared team computers or isolated private ones, reachable from web, desktop, and mobile with voice mode. Bots delegate to peer bots or short-lived subagents. BYO model and sandbox.
 - [rho](https://github.com/mikeyobrien/rho) - Stays running, remembers across sessions, and checks in on its own. macOS, Linux, Android.
 - [rowboat](https://github.com/rowboatlabs/rowboat) - Open-source AI coworker with memory.
 - [zclaw](https://github.com/tnm/zclaw) - Complete personal assistant in 888 KiB, running on an ESP32 with GPIO, cron, and custom tools.


### PR DESCRIPTION
Adds [Rakazo](https://github.com/elie222/rakazo) to **Personal Assistants**, alphabetically after `QwenPaw`.

Rakazo is a self-hosted platform for persistent AI teammates with their own conversations, memory, and routines, running on shared team computers or isolated private ones, reachable from web, desktop, and mobile with voice mode. Bots delegate to peer bots or short-lived subagents. BYO model and sandbox.

- 1.2k stars, Apache-2.0, self-hostable, actively developed
- Fits the section: always-on teammates that remember across sessions and hand work off to other agents