### PR TITLE
Add OpenMausBot to Personal Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Always-on agents you reach over chat or a desktop app. They remember across sess
 - [nanoclaw](https://github.com/nanocoai/nanoclaw) - Lightweight OpenClaw alternative running in containers, connecting to WhatsApp, Telegram, Slack, Discord, and Gmail.
 - [nullclaw](https://github.com/nullclaw/nullclaw) - Fully autonomous assistant infrastructure written in Zig.
 - [openclaw](https://github.com/openclaw/openclaw) - Your own personal AI assistant, on any OS and any platform.
+- [OpenMausBot](https://github.com/milind-soni/OpenMausBot) - Open-source Grok Bot-style team of bots in a chat-app sidebar, where every bot is a real local agent — Claude or Codex — with its own personality, model, cloud computer, and connected apps, behind approval gates. Local-first, bring-your-own-agent.
 - [Ouroboros](https://github.com/razzant/ouroboros) - General-purpose agent with durable identity and memory, reviewed self-modification, multi-agent coordination, and desktop and headless interfaces.
 - [picoclaw](https://github.com/sipeed/picoclaw) - Tiny and fast assistant deployable anywhere.
 - [QwenPaw](https://github.com/agentscope-ai/QwenPaw) - Personal assistant that deploys to your own machine or the cloud and plugs into multiple chat apps. Formerly CoPaw.


### PR DESCRIPTION
Adds [OpenMausBot](https://github.com/milind-soni/OpenMausBot) to **Personal Assistants**, alphabetically after `openclaw`.

OpenMausBot is an open-source Grok Bot-style team of bots in a chat-app sidebar, where every bot is a real local agent — Claude or Codex — with its own personality, model, cloud computer, and connected apps, behind approval gates. Local-first, bring-your-own-agent.

- 1.5k stars, Apache-2.0, actively developed
- Fits the section: always-on chat-app bots you delegate to, same shape as Rakazo/Grok Bot