### PR TITLE
Add Okto Nexus project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [LionClaw](https://github.com/moshthepitt/lionclaw) - Local control plane running coding agents as durable, auditable workers with explicit state, skills, and checkpoints.
 - [NemoClaw](https://github.com/NVIDIA/NemoClaw) - Runs Hermes, LangChain Deep Agents, and OpenClaw inside NVIDIA OpenShell with managed inference.
 - [neuralyzer](https://github.com/gintasz/neuralyzer) - Lets an agent wipe its own session context and re-run the first message, making Ralph loops easier to engineer.
+- [Okto Nexus](https://github.com/OktoLabsAI/okto-nexus) - Local-first MCP coordination hub giving agents durable identities, messaging, single-winner handoff claims, and governance (policies, guardrails, human approval), all from one hub with no cloud broker.
 - [omnigent](https://github.com/omnigent-ai/omnigent) - Meta-harness running Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, or custom YAML agents against swappable sandbox backends, with policy enforcement.
 - [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) - TypeScript-native runtime where a coordinator turns a goal into a task DAG and a deterministic scheduler runs specialized agents, with approvals, traces, evaluation, checkpoints, and resume support.
 - [openfang](https://github.com/RightNow-AI/openfang) - Open-source agent operating system.


### PR DESCRIPTION
Adds Okto Nexus under Agent Infrastructure & Primitives.

Okto Nexus is a local-first MCP coordination hub for teams of AI coding agents. It gives agents durable identities, presence, and messaging, single-winner handoff claims so two agents can't start the same work, dependency-aware handoffs with verification, and governance controls (policies, guardrails, human-in-the-loop approval) — all from one local hub with no cloud broker.

It fits Agent Infrastructure & Primitives specifically, not Multi-Agent Swarms — Nexus doesn't spawn or run agents itself, it's the coordination layer already-running agents connect to. Closest existing entries are swarm-protocol (headless MCP coordination, claim/heartbeat/handoff) and guild (single-binary shared coordination over local SQLite) — Nexus adds durable messaging, human approval gates, and versioned governance policies on top of that same shape.

Active development, recent commits, public repo with a working README, CONTRIBUTING.md, and LICENSE (Elastic-2.0).