### PR TITLE
Add Vicoa to Parallel Coding Agents — Desktop & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [Traycer](https://github.com/traycerai/traycer) - Bring-your-own-agent workspace running many sessions in parallel with context shared across models and providers, plus agent-to-agent messaging, shareable boards, and cross-device sync.
 - [vibe-tree](https://github.com/sahithvibudhi/vibe-tree) - One git worktree per agent, delivered as desktop, web, and CLI.
 - [vibecraft](https://github.com/rayzhudev/vibecraft) - RTS-style workspace for commanding coding agents.
+- [Vicoa](https://github.com/vicoa-ai/vicoa) - Agentic IDE and AI orchestrator for running a team of coding agents from desktop, web, or mobile, with real-time sync, parallel git worktrees, and push notifications. Claude Code, Codex, OpenCode, Gemini, Cursor, GitHub Copilot, Kimi, Hermes.
 - [Waku](https://github.com/egoist/waku) - Native macOS desktop app for working with local coding agents, keeping projects, sessions, and transcripts on your machine. Supports Amp, Claude Code, Codex CLI, Cursor CLI, Grok Build, OpenCode, and Pi.
 - [Zaivern Code](https://github.com/tacyan/zaivern-code) - Cross-platform Rust desktop cockpit for running Claude Code, Codex, Gemini CLI, and 30+ coding agents in parallel, with fleet monitoring, mobile control, and line-level ownership to prevent merge conflicts.
 


### PR DESCRIPTION
## What

Adds [Vicoa](https://github.com/vicoa-ai/vicoa) to the Parallel Coding Agents — Desktop & Web section, alongside similar cross-device orchestrators (Comet, Garcon, IM.codes, intentic, Orca, Paseo).

## About the project

Vicoa is an open-source, self-hostable agentic IDE and AI orchestrator for running a team of coding agents (Claude Code, Codex, OpenCode, Gemini, Cursor, GitHub Copilot, Kimi, Hermes) from desktop, web, or mobile, with real-time sync, parallel git worktrees, and push notifications.

Full disclosure: I'm one of the maintainers. It's a young project (~30 stars) but functional and actively developed.