### PR TITLE
Add YYLO to Parallel Coding Agents — Terminal (TUI/CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Run and supervise several agent sessions side by side from a terminal — tmux p
 - [repomon](https://github.com/AliHamzaAzam/repomon) - Rust TUI that supervises a fleet across many repositories at once, in durable tmux sessions you can approve from your phone.
 - [thurbox](https://github.com/Thurbeen/thurbox) - TUI orchestrator with remote SSH sessions, inter-session messaging, and a native code-review view. Works with any CLI agent you define.
 - [tmux-ide](https://github.com/wavyrai/tmux-ide) - Turns any project into a tmux IDE from a checked-in `ide.yml`, including preset agent-team layouts.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries: each task runs in a dedicated branch and worktree, and a risk-based merge queue reviews the result with receipt-backed changes. Pi and Codex subagents.
 
 ## Parallel Coding Agents — Desktop & Web
 


### PR DESCRIPTION
## Description

Adds [YYLO](https://github.com/yylo-dev/yylo) — a command-line orchestrator for coding agents — to **Parallel Coding Agents — Terminal (TUI/CLI)**, alphabetically after `tmux-ide`.

YYLO decides what an agent works on and what happens to its output, which matches the list's scope line: each task gets a dedicated branch and worktree, typed task/validation/merge/release-readiness boundaries, and a risk-based merge queue that reviews the result with receipt-backed changes. It sits naturally beside the worktree- and kanban-flavored terminal orchestrators already listed (`amux`, `claude-squad`, `dmux`, `openkanban`).

## Checklist

- [x] One entry, one line, `+1/−0` on `README.md` — same shape as recent merges (#192, #190)
- [x] Alphabetical position within the section (YYLO sorts after `tmux-ide`)
- [x] Description phrases are quotable from the project's README ("command-line orchestrator for coding agents", "typed task, validation, merge, and release-readiness boundaries", "dedicated branch/worktree", risk-based merge queue, receipts; supported subagents: Pi and Codex)
- [x] Actively maintained: daily pushes since January 2026, MIT-licensed, installable via npm `@yylo/cli` — so it should stay out of **Resting**

## Disclosure

I maintain yylo-dev and prepared this PR with an AI coding agent; happy to adjust wording or section if you see a better fit.
