### PR TITLE
Add ai-devkit — CLI control plane for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Run and supervise several agent sessions side by side from a terminal — tmux p
 - [agent-of-empires](https://github.com/agent-of-empires/agent-of-empires) - Pairs a TUI with a matching web view, so the same sessions stay reachable from a phone. Claude Code, Codex, OpenCode, Gemini, Mistral Vibe.
 - [agentbox](https://github.com/madarco/agentbox) - Gives each agent its own sandboxed VM — local Docker or cloud via Hetzner, Daytona, Vercel, or E2B — with sub-second checkpoint starts.
 - [agterm](https://github.com/umputun/agterm) - Native macOS terminal with named workspaces, a live dashboard, attention states, and a scriptable control API.
+- [ai-devkit](https://github.com/codeaholicguy/ai-devkit) - CLI control plane that runs agent sessions in managed tmux, sends prompts and logs to running agents from the terminal or a TUI console, and gives every agent one setup with shared local memory, verification skills, and lifecycle workflows. Claude Code, Codex, Pi, and more.
 - [amux](https://github.com/andyrewlee/amux) - Minimal TUI for spawning parallel coding agents in git worktrees.
 - [claude-squad](https://github.com/smtg-ai/claude-squad) - Runs each agent as a detached background session with its own worktree, so work continues after you close the pane. Claude Code, Codex, OpenCode, Amp.
 - [cmux](https://github.com/manaflow-ai/cmux) - Ghostty-based macOS terminal with vertical tabs and per-agent notifications, built for keeping many concurrent sessions legible.


### PR DESCRIPTION
## What

[ai-devkit](https://github.com/codeaholicguy/ai-devkit) — a CLI control plane for AI coding agents.

## Why it fits

Per the list's scope — *decides what an agent works on, when it runs, where it runs, or what happens to its output* — ai-devkit:

- runs agent sessions in managed tmux sessions and supervises them from a TUI console
- routes prompts, logs, and stdin to running agents via `agent send` from the terminal, a phone via channel bridges, or the console
- gives every agent one setup model (hooks, skills, MCP) with shared local-first memory and verification skills
- dispatches multi-agent dev-lifecycle workflows (requirements → … → review) and durable one-shot agents

Works with Claude Code, Codex, Pi, and more.

Added under **Parallel Coding Agents — Terminal (TUI/CLI)**, alphabetical (first in section). One line, matching the section's format.