### PR TITLE
Add lolabot to Personal Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Always-on agents you reach over chat or a desktop app. They remember across sess
 - [lemon](https://github.com/z80dev/lemon) - Local-first assistant and coding agent runtime.
 - [leon](https://github.com/leon-ai/leon) - Long-running open-source personal assistant with voice and text interfaces.
 - [lobsterai](https://github.com/netease-youdao/LobsterAI) - Desktop-grade agent for data analysis, slides, docs, and web research.
+- [lolabot](https://github.com/23blocks-OS/lolabot) - Chief-of-staff assistant for Claude Code that handles email, keeps semantic memory across sessions, and tracks tasks. Runs standalone or on AI Maestro.
 - [lucinate](https://github.com/lucinate-ai/lucinate) - Terminal-native chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible providers, with cron management and session browsing.
 - [MetaClaw](https://github.com/aiming-lab/MetaClaw) - Assistant that learns and evolves from conversation alone.
 - [nanobot](https://github.com/HKUDS/nanobot) - Ultra-lightweight self-hosted assistant in Python with WebUI, tools, memory, MCP, and multi-agent workflows.


### PR DESCRIPTION
[lolabot](https://github.com/23blocks-OS/lolabot) — a chief-of-staff assistant for Claude Code. It stays running, handles email, keeps semantic memory across sessions, and tracks tasks, so you message it rather than opening a tool. Works standalone or on top of AI Maestro.

MIT, actively maintained (last push this week).

Placement: alphabetically between `lobsterai` and `lucinate` in **Personal Assistants**, matching the section's sort order. Single-line addition.