### PR TITLE
Add Agent Messaging Protocol to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Unattended agents driven by an external source — an issue queue, a work board,
 
 Control planes, coordination protocols, harness adapters, and runtimes — the layer beneath your agents rather than the surface you work in.
 
+- [Agent Messaging Protocol](https://github.com/agentmessaging/protocol) - Open standard for agent-to-agent messaging with Ed25519-signed envelopes, federation across providers, and delivery that must be proven rather than assumed. Reference server, TypeScript SDK, and a Claude Code plugin.
 - [agent-runbook](https://github.com/KnoxOps/agent-runbook) - Compiles YAML runbooks with loops, branching, and parallelism into SKILL.md files for Claude Code and Codex.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Keeps specialist agents in a hub and spins up a temporary orchestrator per task, with A2A routing and governed memory gates. Formerly Hephaestus.
 - [agenttier](https://github.com/agenttier/agenttier) - Kubernetes runtime giving each agent its own Pod and PVC sandbox behind a default-deny NetworkPolicy, with a streaming SSE invoke API.


### PR DESCRIPTION
[Agent Messaging Protocol](https://github.com/agentmessaging/protocol) (AMP) — an open standard for agent-to-agent messaging: Ed25519-signed envelopes, federation across providers, allowlist ACLs, and a delivery model where arrival has to be proven rather than assumed.

Sits alongside the other coordination protocols already in this section (Concord MCP, foremerge, swarm-protocol) — it is the messaging layer beneath an orchestrator rather than a surface you work in.

Apache-2.0. The spec is the repo; there is also a reference server, a TypeScript SDK, and a Claude Code plugin under the same org.

Placement: alphabetically ahead of `agent-runbook` in **Agent Infrastructure & Primitives**. Single-line addition.