### PR TITLE
Add Agent Identity to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Unattended agents driven by an external source — an issue queue, a work board,
 
 Control planes, coordination protocols, harness adapters, and runtimes — the layer beneath your agents rather than the surface you work in.
 
+- [Agent Identity](https://github.com/agentmessaging/agent-identity) - Lets an agent authenticate to an OAuth 2.0 server with its own Ed25519 key rather than a shared API key, exchanging a signed identity and proof of possession for a standard JWT. Spec, reference flows, and installer.
 - [agent-runbook](https://github.com/KnoxOps/agent-runbook) - Compiles YAML runbooks with loops, branching, and parallelism into SKILL.md files for Claude Code and Codex.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Keeps specialist agents in a hub and spins up a temporary orchestrator per task, with A2A routing and governed memory gates. Formerly Hephaestus.
 - [agenttier](https://github.com/agenttier/agenttier) - Kubernetes runtime giving each agent its own Pod and PVC sandbox behind a default-deny NetworkPolicy, with a streaming SSE invoke API.


### PR DESCRIPTION
[Agent Identity (AID)](https://github.com/agentmessaging/agent-identity) — MIT, spec + reference flows at [agentids.org](https://agentids.org).

An agent authenticates to an OAuth 2.0 server using its own Ed25519 key instead of a shared API key: it presents a signed identity, proves possession of the private key, and gets back a standard RS256 JWT. Nothing to rotate and no secret sitting in an agent's environment, which is the part that gets awkward once you are running more than a handful of agents.

Fits the section as infrastructure beneath the agents rather than a harness you work in. Independent and self-contained — it does not require any other protocol or tool.

Heads up: #199 inserts a line at the same spot, so whichever merges second will need a one-line rebase. Ping me and I will do it right away.