### PR TITLE
Add Agent Actions Protocol to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Unattended agents driven by an external source — an issue queue, a work board,
 
 Control planes, coordination protocols, harness adapters, and runtimes — the layer beneath your agents rather than the surface you work in.
 
+- [Agent Actions Protocol](https://github.com/agentmessaging/agent-actions) - Open protocol for structured UI-to-agent interactions: clicks and form input in HTML an agent rendered come back as immutable JSON records it can read, instead of console scraping or a WebSocket per page.
 - [agent-runbook](https://github.com/KnoxOps/agent-runbook) - Compiles YAML runbooks with loops, branching, and parallelism into SKILL.md files for Claude Code and Codex.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Keeps specialist agents in a hub and spins up a temporary orchestrator per task, with A2A routing and governed memory gates. Formerly Hephaestus.
 - [agenttier](https://github.com/agenttier/agenttier) - Kubernetes runtime giving each agent its own Pod and PVC sandbox behind a default-deny NetworkPolicy, with a streaming SSE invoke API.


### PR DESCRIPTION
[Agent Actions Protocol (AAP)](https://github.com/agentmessaging/agent-actions) — MIT, spec v1.0.

When an agent renders an HTML dashboard or form, the user's clicks have no standard way back to the agent. AAP defines one bridge script, one message format, and one storage pattern: the interaction is written as an immutable JSON record the agent reads, replacing console-log scraping, DOM polling, or a bespoke WebSocket per page.

**One scope question, honestly:** the section describes "the layer beneath your agents rather than the surface you work in," and AAP is arguably about the surface. I think it belongs here because it is a wire protocol and storage contract rather than a UI, and it sits under whatever interface an agent renders — but you curate this list, and if you read it as out of scope I will close this without argument. The other three PRs stand on their own either way.

Heads up: #199 and #200 insert a line at the same spot, so whichever merges last needs a one-line rebase. Happy to do it.