### PR TITLE
Add OrcaReplay to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [omnigent](https://github.com/omnigent-ai/omnigent) - Meta-harness running Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, or custom YAML agents against swappable sandbox backends, with policy enforcement.
 - [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) - TypeScript-native runtime where a coordinator turns a goal into a task DAG and a deterministic scheduler runs specialized agents, with approvals, traces, evaluation, checkpoints, and resume support.
 - [openfang](https://github.com/RightNow-AI/openfang) - Open-source agent operating system.
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records a coding agent at the process and socket boundary so model traffic, shell exit codes, per-turn file changes and MCP JSON-RPC share one timeline, then replays the run offline with the network off or forks it from a checkpoint onto a different model.
 - [sandbox-agent](https://github.com/rivet-dev/sandbox-agent) - Daemon, HTTP/SSE API, and TypeScript SDK for driving six coding agents inside E2B, Daytona, Modal, Cloudflare Containers, or Docker.
 - [skillfold](https://github.com/byronxlg/skillfold) - Declares skills in YAML and pins exact revisions in a lockfile so installs are reproducible across Claude Code and Codex.
 - [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Portable Markdown definitions that route a task to a chosen backend, model, effort level, and permission set.


### PR DESCRIPTION
Adds OrcaReplay to **Agent Infrastructure & Primitives**, placed alphabetically.

Your framing for that section — "the layer beneath your agents rather than the surface you work in" — is literally where this sits. Capture happens at the process and socket boundary, not inside the agent, so one timeline holds the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP JSON-RPC calls. Because the interception is below the base-URL variable, it also works on harnesses that read none — a Codex CLI on a ChatGPT subscription talks only to its own backend and is still captured.

`aGiTrack` is the nearest neighbour already listed: it commits each turn to git with the prompt and model. OrcaReplay keeps the same per-turn record but makes it executable — `orca replay` serves the recorded responses back with the network off so the run repeats on another machine, and `orca fork` restarts from a chosen checkpoint against a different model with earlier turns still served from the recording, so an orchestration or model comparison starts from identical state.

One thing worth knowing rather than discovering: the byte-for-byte guarantee is conditional. It holds when the prompt was recorded through argv (`orca record claude -- -p "…"`); a hand-driven terminal session replays the conversation but not the run byte for byte, because the harness makes calls for itself that a replay does not repeat and interactive-only tools are absent without a person. The README says this rather than glossing it.

Apache-2.0, on npm as `orcareplay` (Node 20+). Repository is nine days old with 150 stars.
