### PR TITLE
Add lucidos to Personal Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Always-on agents you reach over chat or a desktop app. They remember across sess
 - [lemon](https://github.com/z80dev/lemon) - Local-first assistant and coding agent runtime.
 - [leon](https://github.com/leon-ai/leon) - Long-running open-source personal assistant with voice and text interfaces.
 - [lobsterai](https://github.com/netease-youdao/LobsterAI) - Desktop-grade agent for data analysis, slides, docs, and web research.
+- [lucidos](https://github.com/lucidos-dev/lucidos) - Describe an app or an automation in chat and it writes one, then keeps it running beside the thread: generated apps get their own UI over the same files and event store, triggers fire on a schedule or on an event, and threads spawn Claude Code or Codex sessions whose changes you apply from the same place. Rust engine, one installer for macOS, bring your own model, MIT.
 - [lucinate](https://github.com/lucinate-ai/lucinate) - Terminal-native chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible providers, with cron management and session browsing.
 - [MetaClaw](https://github.com/aiming-lab/MetaClaw) - Assistant that learns and evolves from conversation alone.
 - [nanobot](https://github.com/HKUDS/nanobot) - Ultra-lightweight self-hosted assistant in Python with WebUI, tools, memory, MCP, and multi-agent workflows.


### PR DESCRIPTION
Adds **lucidos** to Personal Assistants, alphabetically between `lobsterai` and `lucinate`.

**What it is:** a self-hosted assistant that stays running, remembers across sessions, and picks up work from a chat thread, which is the section's definition. The part that is not already on the list: you describe an app or an automation and it writes one, then runs it beside the thread. Generated apps get their own UI over the same files and event store the chat uses, triggers fire on a schedule or on an event, and a thread can spawn Claude Code or Codex sessions whose changes you review and apply from the same place.

**Why it is an orchestrator and not something an agent merely consumes:** it decides what runs and when. Cron and event triggers start threads on their own, threads spawn child threads and coding-agent sessions, and a queue admits or defers them against a concurrency policy.

- Rust engine, TypeScript frontend, one installer for macOS
- Bring your own model (Anthropic, OpenAI, Vertex, OpenRouter, local)
- MIT licensed, all data on your own machine
- Actively maintained, currently v0.35.1

Entry format matches the surrounding lines, no trailing whitespace, one entry in one section.
