### PR TITLE
docs: add LongHorizon-Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The "keep running until done" pattern — a single goal driven through a retry-u
 - [bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Keeps no model in the coordination loop, so orchestration costs zero tokens. Verifies with tests and auto-commits across 40+ CLI agents.
 - [Dex](https://github.com/francescoalemanno/dex) - Human-gated planning, multi-reviewer code review, and dead-end-aware research loops, shipped as cross-platform binaries for 7 CLI backends.
 - [fractal](https://github.com/plasma-ai/fractal) - Loops that recursively delegate separable subtasks to child agents, bounded by configurable depth, cost, and time limits.
+- [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness) - Long-running computer-use harness with fresh-context execution, independent auditing, and verified checkpoints across desktop apps and CLI workflows. Claude Code, Codex, OpenCode, DeepSeek Harness.
 - [Loop Engineering](https://github.com/cobusgreyling/loop-engineering) - Designs repeatable coding-agent loops around automation, worktrees, skills, state, and verification, with starters and a Loop Ready score for Grok, Claude Code, Codex, and OpenCode.
 - [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - An LLM council plans the work, then Ralph-style loops retry failed units with fresh context. Executes via OpenCode worktrees.
 - [MartinLoop](https://github.com/Keesan12/martin-loop) - Caps spend, enforces policy, verifies output, and rolls back failures, leaving inspectable run receipts.


### PR DESCRIPTION
## Summary

Closes #155 by adding [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness) to the **Autonomous Loop Runners** section. It provides fresh-context execution, independent auditing, verified checkpoints, and recovery for long-running desktop and CLI agent workflows.

The entry is placed alphabetically and follows the existing one-line README format.

## Validation

- `git diff --check`
- README entry placement and link checks passed
- No executable test suite is present in this README-only repository change