### PR TITLE
Add Speakeasy to Agent Infrastructure & Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Control planes, coordination protocols, harness adapters, and runtimes — the l
 - [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) - TypeScript-native runtime where a coordinator turns a goal into a task DAG and a deterministic scheduler runs specialized agents, with approvals, traces, evaluation, checkpoints, and resume support.
 - [openfang](https://github.com/RightNow-AI/openfang) - Open-source agent operating system.
 - [sandbox-agent](https://github.com/rivet-dev/sandbox-agent) - Daemon, HTTP/SSE API, and TypeScript SDK for driving six coding agents inside E2B, Daytona, Modal, Cloudflare Containers, or Docker.
+- [Speakeasy](https://www.speakeasy.com/) - Enterprise AI control plane for governing access, policy, and auditability across agents, MCP servers, and Skills.
 - [skillfold](https://github.com/byronxlg/skillfold) - Declares skills in YAML and pins exact revisions in a lockfile so installs are reproducible across Claude Code and Codex.
 - [sub-agents-skills](https://github.com/shinpr/sub-agents-skills) - Portable Markdown definitions that route a task to a chosen backend, model, effort level, and permission set.
 


### PR DESCRIPTION
Adds Speakeasy to Agent Infrastructure & Primitives. It is an enterprise AI control plane for governing access, policy, and auditability across agents, MCP servers, and Skills.
