### PR TITLE
Add lmux — native macOS workbench for CodeBuddy Code & Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [jat](https://github.com/joewinke/jat) - Visual dashboard combining live sessions, task management, code editor, and terminal, with parallel swarm workflows.
 - [jean](https://github.com/coollabsio/jean) - Desktop and web app for orchestrating agents across multiple projects and their git worktrees. Claude, Codex, OpenCode.
 - [kandev](https://github.com/kdlbs/kandev) - Kanban workbench whose multi-step workflows assign a different agent per step behind human gates, running locally, in Docker, over SSH, or in cloud executors.
+- [lmux](https://github.com/LiManshiang/lmux) - Native macOS workbench for running CodeBuddy Code and Claude Code in parallel sessions, with per-conversation context and credit meters, automatic conversation resume (including on another Mac), and cross-Mac session sync. CodeBuddy Code, Claude Code.
 - [mux](https://github.com/coder/mux) - Desktop app for isolated, parallel agentic development.
 - [MonoCode](https://github.com/hardbeat920/monocode) - Tauri desktop UI where tabs are agent sessions, running Claude Code, Codex, Cursor, Grok Build, OpenCode, Pi, omp, and fx on your existing subscriptions. macOS, Linux, and Windows.
 - [nimbalyst](https://github.com/nimbalyst/nimbalyst) - Visual workspace pairing parallel worktree sessions with kanban and direct visual editing. Claude Code, Codex, OpenCode.


### PR DESCRIPTION
Adds [lmux](https://github.com/LiManshiang/lmux) to **Parallel Coding Agents — Desktop & Web**
(alphabetical position, after `kandev`).

lmux is a native macOS (SwiftUI) workbench for running CodeBuddy Code and Claude Code agents
side by side:

- Per-conversation context-window and credit meters (exact for CodeBuddy, estimated for Claude)
- Automatic conversation resume, including on a different Mac (imports localize recorded paths)
- Cross-Mac session sync through any shared folder, with keep-local / use-remote conflict handling
- Ghostty GPU-rendered terminal; a SwiftTerm backend keeps macOS 12 and Intel Macs supported
- MIT licensed and local-first: agents run in local terminals, data stays in the home directory

Unlike terminals that merely attach a resume command, lmux is built on **CodeBuddy Code's own
session store**: conversations are discovered automatically from `~/.codebuddy`, context-window
and credit usage are read exactly from each conversation's JSONL, and that same data powers
resume and cross-Mac sync.

Built with `make app`; releases ship as a signed-zip + Homebrew cask
(`brew tap LiManshiang/lmux && brew trust limanshiang/lmux && brew install --cask lmux`).
