### PR TITLE
Fix Orkas entry: OpenClaw and Hermes, not Cline

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Systems where multiple specialized agents actively coordinate, communicate, and 
 - [NXTG-Forge Orchestrator](https://github.com/nxtg-ai/forge-orchestrator) - Coordinates Claude Code, Codex, and Gemini CLI on one shared repo through a research-plan-delegate-adversarial-verify-deploy pipeline, with file locking, knowledge capture, and drift detection. Single Rust binary.
 - [orc](https://github.com/spencermarx/orc) - Lightweight framework that piggybacks your existing CLI setup for planning, task decomposition, worktrees, and review.
 - [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime managing agents as typed teams with an explicit state machine and goals. Claude Code, Codex, Cursor.
-- [Orkas](https://github.com/Orkas-AI/Orkas) - A commander agent decomposes goals and dispatches specialists with isolated skills and memory. Claude Code, Codex, OpenCode, Cline.
+- [Orkas](https://github.com/Orkas-AI/Orkas) - A commander agent decomposes goals and dispatches specialists with isolated skills and memory. Claude Code, Codex, OpenCode, OpenClaw, Hermes.
 - [OtoDock](https://github.com/OtoDock/oto-dock) - Self-hosted "company OS" where agents work in departments, delegate to each other, and keep working unwatched on your Anthropic/OpenAI subscriptions — company map, per-agent dashboards, artifacts, meetings, and terminals. Source-available under FSL-1.1.
 - [paperclip](https://github.com/paperclipai/paperclip) - Self-hosted platform where agents wake on heartbeats to claim tickets, governed by org charts, budgets, and approval gates.
 - [ruflo](https://github.com/ruvnet/ruflo) - Meta-harness for deploying coordinated swarms and conversational multi-agent workflows. Formerly claude-flow.


### PR DESCRIPTION
One-line correction to the existing Orkas entry under Multi-Agent Swarms.

Orkas has never supported Cline as an external CLI backend. The backends it can run as local sessions are **Claude Code, Codex, OpenCode, OpenClaw, and Hermes** — five, not four. The upstream README lists them under "Drives the open-source ecosystem": https://github.com/Orkas-AI/Orkas#why-orkas

Nothing else in the entry changes.

I maintain Orkas, so happy to answer anything — and thanks for keeping the list accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)