### PR TITLE
Add AI4Kanban

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 - [agent-squid](https://github.com/agent-squid/squid) - Browser UI organized into named lanes (`#topic@agent`), with context shared across agents and a realtime quota gauge.
 - [AGX](https://github.com/ramarlina/agx) - Wake-work-sleep checkpointing keeps a persistent agent team on long objectives, with human gates between cycles.
 - [ai-maestro](https://github.com/23blocks-OS/ai-maestro) - Dashboard spanning multiple machines, adding memory search, code-graph queries, and agent-to-agent messaging. Claude, Aider, Cursor.
+- [AI4Kanban](https://github.com/ai4kanban/ai4kanban) - AI project manager that turns rough ideas into actionable tasks, coordinates coding agents through planning and implementation, and builds shared project memory from decisions. Humans steer priorities and make key decisions through a desktop and web interface.
 - [aizen](https://github.com/vivy-company/aizen) - macOS workspace that organizes worktrees, environments, and agent sessions per project.
 - [Alethe](https://github.com/Kc1t/alethe-agents) - Local-first desktop workspace where agents and shells run as real PTYs in split panes and custom grids across projects, surviving pane close and app restart. Suspend idle groups to reclaim memory and resume with scrollback intact. Claude Code, Codex, OpenCode.
 - [Aperant](https://github.com/AndyMik90/Aperant) - Runs up to 12 agent terminals with a self-validating QA loop and automatic conflict resolution when merging back to main.


### PR DESCRIPTION
Adds AI4Kanban under Parallel Coding Agents — Desktop & Web.

AI4Kanban is an AI project manager that turns rough ideas into actionable tasks, coordinates coding agents through planning and implementation, and retains shared project memory. Its desktop and web interface lets people steer priorities and make key decisions.

Disclosure: I maintain AI4Kanban.

Validation: checked the project link, confirmed there is no existing entry or matching PR, and ran `git diff --check`. This change adds one README entry.
