### PR TITLE
Add AgentGrid to desktop agent orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The same parallel-sessions workflow as a desktop app or browser/mobile dashboard
 
 - [agent-orchestrator](https://github.com/Untrivial-ai/agent-orchestrator) - Agent IDE for fleets that plans the work, spawns the agents, then fixes CI failures and merge conflicts without being asked.
 - [agent-squid](https://github.com/agent-squid/squid) - Browser UI organized into named lanes (`#topic@agent`), with context shared across agents and a realtime quota gauge.
+- [AgentGrid](https://agentgrid.sh/) - Desktop canvas for orchestrating Claude Code, Codex, and other coding agents, with visible worker conversations, shared notes and browser panes, and git-worktree management. macOS, Windows, and Linux; closed-source with a free tier.
 - [AGX](https://github.com/ramarlina/agx) - Wake-work-sleep checkpointing keeps a persistent agent team on long objectives, with human gates between cycles.
 - [ai-maestro](https://github.com/23blocks-OS/ai-maestro) - Dashboard spanning multiple machines, adding memory search, code-graph queries, and agent-to-agent messaging. Claude, Aider, Cursor.
 - [AI4Kanban](https://github.com/ai4kanban/ai4kanban) - AI project manager that turns rough ideas into actionable tasks, coordinates coding agents through planning and implementation, and builds shared project memory from decisions. Humans steer priorities and make key decisions through a desktop and web interface.


### PR DESCRIPTION
Adds AgentGrid to **Parallel Coding Agents — Desktop & Web**, beside the other desktop workspaces. The entry describes its visual worker conversations, shared project context and worktree management, and explicitly identifies it as closed-source with a free tier.

Sources checked:
- [Product overview](https://agentgrid.sh/): visible canvas, worker conversations, notes, browser and source-control surfaces.
- [Orchestration guide](https://agentgrid.sh/docs/guides/orchestrating-agents): master/worker delegation and follow-ups.
- [Harness setup](https://agentgrid.sh/docs/getting-started/cli-prerequisites): Claude Code and Codex can run as masters or workers.
- [Installation](https://agentgrid.sh/docs/getting-started/installation): macOS, Windows and Linux installers.
- [Pricing](https://agentgrid.sh/pricing): free tier; provider subscriptions remain separate.

Validation: one added README line, matching the section's entry format and alphabetical placement; no duplicate AgentGrid entry or existing AgentGrid PR found; `git diff --check` passes. No build or runtime code changed.

Disclosure: this contribution was prepared by an AI assistant working for the AgentGrid team. The product source is private; the linked website and documentation are public. No comparative performance or adoption claim is made.
