### PR TITLE
Add YYLO Ledger to Parallel Coding Agents — Terminal (TUI/CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Run and supervise several agent sessions side by side from a terminal — tmux p
 - [thurbox](https://github.com/Thurbeen/thurbox) - TUI orchestrator with remote SSH sessions, inter-session messaging, and a native code-review view. Works with any CLI agent you define.
 - [tmux-ide](https://github.com/wavyrai/tmux-ide) - Turns any project into a tmux IDE from a checked-in `ide.yml`, including preset agent-team layouts.
 - [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries: each task runs in a dedicated branch and worktree, and a risk-based merge queue reviews the result with receipt-backed changes. Pi and Codex subagents.
+- [YYLO Ledger](https://github.com/yylo-dev/yylo-ledger) - Git-native task and record store for coding-agent workflows: task history lives in stable Markdown files with segmented hash-chained, append-only ledgers, dependency-aware work, receipt and archive packs, and bounded queries from a shell-friendly CLI, with no database as the source of truth. Companion to YYLO.
 
 ## Parallel Coding Agents — Desktop & Web
 


### PR DESCRIPTION
## Description

Adds [YYLO Ledger](https://github.com/yylo-dev/yylo-ledger) — a Git-native task and record store for coding-agent workflows — to **Parallel Coding Agents — Terminal (TUI/CLI)**, alphabetically after `YYLO` (the CLI sibling already listed here, merged in #195; this is a separate project, one entry per PR).

YYLO Ledger owns task state and history while the CLI owns orchestration: task history lives in stable Markdown files with segmented hash-chained, append-only ledgers, dependency-aware work, receipt and archive packs, and bounded queries from a shell-friendly CLI, with no database as the source of truth. It sits naturally beside the task/board-flavored terminal tools in this section (`openkanban`, `pappardelle`).

## Checklist

- [x] One entry, one line, `+1/−0` on `README.md` — same shape as recent merges (#190, #192, #214)
- [x] Alphabetical position within the section (YYLO Ledger sorts after YYLO)
- [x] Description phrases are quotable from the project's README ("Git-native task and Record store with a shell-friendly CLI", "append-only history, dependency-aware work, and bounded queries", "Hot task state lives in stable Markdown files", "segmented hash-chained ledgers retain mutation history", "without making a database the source of truth"; archive packs per `yylo-ledger archive-pack`)
- [x] Actively maintained: pushed daily since August 2026, MIT-licensed, Python 3, on PyPI as `yylo-ledger` (~930 downloads/month) — so it should stay out of **Resting**

Honest sizing up front: the repo is ~1 month old with 1 star; it is the task-state companion of YYLO CLI (57★, listed above) and YYLO Benchmark within the same daily-active org.

## Disclosure

I maintain yylo-dev and prepared this PR with an AI coding agent; happy to adjust wording or drop the entry if the sibling feels too close.
